### PR TITLE
Add Seequence colour-sequence memory game

### DIFF
--- a/home.js
+++ b/home.js
@@ -22,6 +22,7 @@ const tileHandlers = {
     alternate: () => trackClick('alternate'),
     connex: () => trackClick('connex'),
     heardle: () => trackClick('heardle'),
+    seequence: () => trackClick('seequence'),
 };
 
 window.addEventListener("DOMContentLoaded", () => {

--- a/index.html
+++ b/index.html
@@ -113,6 +113,13 @@
       </a>
     </div>
 
+    <div class="tile" id="seequence">
+      <a class="game" href="/seequence/" aria-label="Play Seequence" style="background-image: linear-gradient(135deg, #3b82f6, #ec4899)">
+        <div class="gameTitle">Seequence</div>
+        <div class="gameInfo">Watch colour patterns and pick the exact order</div>
+      </a>
+    </div>
+
     <div class="tile" id="trak">
       <a class="game" href="/trak/" aria-label="Play Trak" style="background-image: url('./images/trak.png')">
         <div class="gameTitle">Trak</div>
@@ -182,6 +189,7 @@
         <li><a href="/alternate" target="_blank">alternate</a></li>
         <li><a href="/hunt" target="_blank">XY</a></li>
         <li><a href="/guesshue" target="_blank">guess hue</a></li>
+        <li><a href="/seequence" target="_blank">seequence</a></li>
         <li><a href="/trak" target="_blank">trak</a></li>
         <li><a href="/tintuition" target="_blank">tintuition</a></li>
         <li><a href="/heardle" target="_blank">heardle</a></li>

--- a/seequence/index.html
+++ b/seequence/index.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Seequence | PlayNerdle</title>
+  <meta name="description" content="Memorise and identify colour sequences in Seequence.">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Condensed&display=swap">
+  <link rel="stylesheet" href="seequence.css">
+</head>
+<body>
+  <main class="game-wrap">
+    <a class="home-link" href="/">← Back to PlayNerdle</a>
+    <h1>Seequence</h1>
+    <p class="subtitle">Memorise the colours, then pick the matching sequence.</p>
+
+    <section class="scoreboard">
+      <div>Score: <strong id="score">0</strong></div>
+      <div>Best: <strong id="best-score">0</strong></div>
+      <div>Level: <strong id="level">1</strong></div>
+    </section>
+
+    <section class="sequence-stage">
+      <h2>Watch</h2>
+      <div id="sequence-display" class="sequence-display" aria-live="polite"></div>
+      <p id="status" class="status">Press Start to begin.</p>
+    </section>
+
+    <section>
+      <h2>Choose the correct order</h2>
+      <div id="options" class="options" role="list"></div>
+    </section>
+
+    <div class="controls">
+      <button id="start-btn" type="button">Start / Restart</button>
+    </div>
+  </main>
+
+  <script src="seequence.js"></script>
+</body>
+</html>

--- a/seequence/seequence.css
+++ b/seequence/seequence.css
@@ -1,0 +1,112 @@
+:root {
+  --bg: #111827;
+  --panel: #1f2937;
+  --text: #f3f4f6;
+  --muted: #9ca3af;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Roboto Condensed', sans-serif;
+  background: radial-gradient(circle at top, #1f2937, #111827 60%);
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.game-wrap {
+  max-width: 860px;
+  margin: 0 auto;
+  padding: 1.5rem;
+}
+
+.home-link {
+  color: #93c5fd;
+  text-decoration: none;
+}
+
+.subtitle,
+.status {
+  color: var(--muted);
+}
+
+.scoreboard {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(100px, 1fr));
+  gap: 0.75rem;
+  margin: 1rem 0;
+}
+
+.scoreboard > div,
+.sequence-stage,
+.options {
+  background: rgba(31, 41, 55, 0.85);
+  border: 1px solid #374151;
+  border-radius: 12px;
+  padding: 0.75rem;
+}
+
+.sequence-display {
+  min-height: 88px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.sequence-pill {
+  width: 68px;
+  height: 68px;
+  border-radius: 14px;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  box-shadow: 0 0 16px rgba(255, 255, 255, 0.15);
+}
+
+.options {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 0.6rem;
+}
+
+.option-btn {
+  width: 100%;
+  border: 1px solid #4b5563;
+  border-radius: 12px;
+  background: #111827;
+  padding: 0.6rem;
+  cursor: pointer;
+}
+
+.option-btn:hover {
+  border-color: #93c5fd;
+}
+
+.option-seq {
+  display: flex;
+  gap: 0.4rem;
+  justify-content: center;
+  flex-wrap: wrap;
+}
+
+.option-swatch {
+  width: 34px;
+  height: 34px;
+  border-radius: 8px;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+}
+
+.controls {
+  margin-top: 1rem;
+}
+
+#start-btn {
+  background: #2563eb;
+  color: #fff;
+  border: 0;
+  border-radius: 10px;
+  padding: 0.7rem 1rem;
+  font-weight: 700;
+  cursor: pointer;
+}

--- a/seequence/seequence.js
+++ b/seequence/seequence.js
@@ -76,14 +76,19 @@ function optionKey(option) {
 function buildOptions(correctSequence, optionCount) {
   const options = [correctSequence];
   const used = new Set([optionKey(correctSequence)]);
+  const sequenceLength = correctSequence.length;
+  let attempts = 0;
+  const maxAttempts = optionCount * 20;
 
-  while (options.length < optionCount) {
-    const candidate = shuffle(correctSequence);
+  while (options.length < optionCount && attempts < maxAttempts) {
+    const candidateSource = options.length < sequenceLength ? correctSequence : palette;
+    const candidate = shuffle(candidateSource).slice(0, sequenceLength);
     const key = optionKey(candidate);
     if (!used.has(key)) {
       used.add(key);
       options.push(candidate);
     }
+    attempts += 1;
   }
 
   return shuffle(options);

--- a/seequence/seequence.js
+++ b/seequence/seequence.js
@@ -1,0 +1,170 @@
+const STORAGE_KEY = 'seequence-best-score';
+
+const state = {
+  active: false,
+  score: 0,
+  level: 1,
+  sequence: [],
+  bestScore: Number(localStorage.getItem(STORAGE_KEY) || 0),
+};
+
+const palette = ['#ef4444', '#22c55e', '#3b82f6', '#eab308', '#f97316', '#a855f7', '#06b6d4', '#ec4899'];
+
+const scoreEl = document.getElementById('score');
+const bestEl = document.getElementById('best-score');
+const levelEl = document.getElementById('level');
+const statusEl = document.getElementById('status');
+const sequenceDisplay = document.getElementById('sequence-display');
+const optionsEl = document.getElementById('options');
+const startBtn = document.getElementById('start-btn');
+
+function shuffle(items) {
+  const arr = [...items];
+  for (let i = arr.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[j]] = [arr[j], arr[i]];
+  }
+  return arr;
+}
+
+function updateHud() {
+  scoreEl.textContent = state.score;
+  levelEl.textContent = state.level;
+  bestEl.textContent = state.bestScore;
+}
+
+function getDifficulty() {
+  const sequenceLength = Math.min(2 + Math.floor((state.level - 1) / 2), 7);
+  const optionCount = Math.min(3 + Math.floor((state.level - 1) / 2), 6);
+  const showMs = Math.max(900 - (state.level - 1) * 70, 420);
+  return { sequenceLength, optionCount, showMs };
+}
+
+function createSequence(len) {
+  return shuffle(palette).slice(0, len);
+}
+
+function renderOptions(options) {
+  optionsEl.innerHTML = '';
+
+  options.forEach((option) => {
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.className = 'option-btn';
+    btn.setAttribute('role', 'listitem');
+
+    const seq = document.createElement('div');
+    seq.className = 'option-seq';
+
+    option.forEach((colour) => {
+      const swatch = document.createElement('span');
+      swatch.className = 'option-swatch';
+      swatch.style.backgroundColor = colour;
+      seq.appendChild(swatch);
+    });
+
+    btn.appendChild(seq);
+    btn.addEventListener('click', () => checkAnswer(option));
+    optionsEl.appendChild(btn);
+  });
+}
+
+function optionKey(option) {
+  return option.join('|');
+}
+
+function buildOptions(correctSequence, optionCount) {
+  const options = [correctSequence];
+  const used = new Set([optionKey(correctSequence)]);
+
+  while (options.length < optionCount) {
+    const candidate = shuffle(correctSequence);
+    const key = optionKey(candidate);
+    if (!used.has(key)) {
+      used.add(key);
+      options.push(candidate);
+    }
+  }
+
+  return shuffle(options);
+}
+
+function wait(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function playSequence() {
+  const { showMs } = getDifficulty();
+  sequenceDisplay.innerHTML = '';
+
+  for (const colour of state.sequence) {
+    const swatch = document.createElement('div');
+    swatch.className = 'sequence-pill';
+    swatch.style.backgroundColor = colour;
+    sequenceDisplay.innerHTML = '';
+    sequenceDisplay.appendChild(swatch);
+    await wait(showMs);
+
+    sequenceDisplay.innerHTML = '';
+    await wait(180);
+  }
+}
+
+function saveBest() {
+  if (state.score > state.bestScore) {
+    state.bestScore = state.score;
+    localStorage.setItem(STORAGE_KEY, String(state.bestScore));
+  }
+}
+
+function gameOver() {
+  state.active = false;
+  saveBest();
+  updateHud();
+  statusEl.textContent = `Game over! Final score: ${state.score}. Press Start to try again.`;
+}
+
+function checkAnswer(option) {
+  if (!state.active) return;
+
+  if (optionKey(option) === optionKey(state.sequence)) {
+    state.score += 1;
+    state.level += 1;
+    statusEl.textContent = 'Correct! Next level...';
+    updateHud();
+    startRound();
+    return;
+  }
+
+  gameOver();
+}
+
+async function startRound() {
+  if (!state.active) return;
+
+  optionsEl.innerHTML = '';
+  const { sequenceLength, optionCount } = getDifficulty();
+  state.sequence = createSequence(sequenceLength);
+  statusEl.textContent = `Level ${state.level}: Watch carefully...`;
+
+  await playSequence();
+
+  if (!state.active) return;
+
+  sequenceDisplay.innerHTML = '';
+  statusEl.textContent = 'Select the correct sequence order.';
+  renderOptions(buildOptions(state.sequence, optionCount));
+}
+
+function startGame() {
+  state.active = true;
+  state.score = 0;
+  state.level = 1;
+  updateHud();
+  statusEl.textContent = 'Get ready...';
+  startRound();
+}
+
+bestEl.textContent = state.bestScore;
+startBtn.addEventListener('click', startGame);
+updateHud();


### PR DESCRIPTION
### Motivation
- Provide a new memory/minigame that shows a short sequence of colours and challenges players to pick the correct chronological order from multiple-choice swatches.
- Make the game progressively harder with longer sequences, more options and faster display speeds as players advance levels.
- Persist the player's best score in `localStorage` so progress is tracked between sessions.

### Description
- Added a new game page with UI and logic in `seequence/index.html`, `seequence/seequence.css`, and `seequence/seequence.js` which implements the game loop, HUD, and responsive styling.
- Implemented difficulty scaling via `getDifficulty()` (controls `sequenceLength`, `optionCount`, and `showMs`) and sequence generation via `createSequence()` and `buildOptions()` where distractor options are permutations of the true sequence's colours.
- Persisted best score in `localStorage` under the key `seequence-best-score` and provided `saveBest()`/display updates in the HUD.
- Integrated the new game into the site by adding a tile and footer link in `index.html` and adding click-tracking for the tile in `home.js` (`seequence` handler added to the tile map).

### Testing
- Ran syntax checks: `node --check home.js` succeeded and `node --check seequence/seequence.js` succeeded.
- Started a local static server with `python3 -m http.server` as part of an automated browser test run, which launched successfully but the Playwright/Chromium browser crashed (SIGSEGV) in this environment, so a full end-to-end screenshot test failed due to the environment crash.
- All in-repo JS syntax checks passed; runtime verification is recommended in a browser (open `/seequence/` and press Start) to validate visual timing and interaction in a normal browser environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dfe4db4c88331b5dadcfd7d18c322)