### PR TITLE
Fix Seequence answers not appearing after sequence playback

### DIFF
--- a/seequence/seequence.js
+++ b/seequence/seequence.js
@@ -76,14 +76,19 @@ function optionKey(option) {
 function buildOptions(correctSequence, optionCount) {
   const options = [correctSequence];
   const used = new Set([optionKey(correctSequence)]);
+  const sequenceLength = correctSequence.length;
+  let attempts = 0;
+  const maxAttempts = optionCount * 20;
 
-  while (options.length < optionCount) {
-    const candidate = shuffle(correctSequence);
+  while (options.length < optionCount && attempts < maxAttempts) {
+    const candidateSource = options.length < sequenceLength ? correctSequence : palette;
+    const candidate = shuffle(candidateSource).slice(0, sequenceLength);
     const key = optionKey(candidate);
     if (!used.has(key)) {
       used.add(key);
       options.push(candidate);
     }
+    attempts += 1;
   }
 
   return shuffle(options);


### PR DESCRIPTION
### Motivation
- The Seequence game could fail to render answer options on early levels because there are fewer unique permutations of a short sequence than the requested number of options.
- The intent is to ensure the options UI always fills and avoid infinite loops when generating candidate sequences.

### Description
- Updated `seequence/seequence.js` `buildOptions` to add bounded retry logic with `maxAttempts` to prevent infinite loops.
- Changed candidate generation to use permutations of the correct sequence first and then fall back to the full `palette` to build remaining options when needed.
- Preserved uniqueness by tracking used option keys with `optionKey` and shuffle the final options before returning.
- No other files were modified.

### Testing
- Launched a local server with `python3 -m http.server 4173` and ran a Playwright script that opens `http://127.0.0.1:4173/seequence/index.html`, clicks `#start-btn`, waits, and inspects the DOM. This succeeded and observed `#options .option-btn` count = 3.
- Captured a screenshot of the rendered options at `artifacts/seequence-options.png` as validation that answer buttons appear after playback.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e0c0aa6f48331b92b5199ac745a57)