### PR TITLE
Heardle: 3-life run, in-area Start button, and motivational between-level messages

### DIFF
--- a/heardle/index.html
+++ b/heardle/index.html
@@ -60,6 +60,27 @@
             flex-direction: column;
             align-items: center;
             padding: 10px;
+            position: relative;
+        }
+
+        #gameAreaMessage {
+            position: absolute;
+            top: 12px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(46, 204, 64, 0.9);
+            color: #111;
+            font-weight: 700;
+            padding: 10px 14px;
+            border-radius: 8px;
+            opacity: 0;
+            pointer-events: none;
+            transition: opacity 0.25s;
+            z-index: 3;
+        }
+
+        #gameAreaMessage.visible {
+            opacity: 1;
         }
 
         /* Large level indicator (hidden by default) */
@@ -320,13 +341,14 @@
             <div>Lives: <span id="livesDisplay">3</span></div>
             <div>Melody Length: <span id="melodyLengthDisplay">3</span></div>
         </div>
-        <div class="control-buttons">
-            <button id="playTargetBtn">Play Target Melody</button>
-        </div>
         <h2>Your Composition</h2>
         <!-- compositionArea holds the temporary level indicator, guess history, and current composition -->
         <div id="compositionArea" title="Click a note to remove it from your composition">
+            <div id="gameAreaMessage"></div>
             <div id="compositionLevel">1</div>
+            <div class="control-buttons">
+                <button id="playTargetBtn">Start / Play Target Melody</button>
+            </div>
             <div id="guessHistory"></div>
             <div id="playerPanel"></div>
         </div>
@@ -343,10 +365,11 @@
         /***************************************
          * Global Configuration & Variables  *
          ***************************************/
+        const startingLives = 3;
         let currentLevel = 1;
         const baseCompositionLength = 3; // starting length for level 1
         let compositionLength = baseCompositionLength; // updates with level progression
-        let lives = 3;
+        let lives = startingLives;
         // Variables for target melody replays.
         const baseReplays = 2;
         let remainingReplays;  // replays left for the current level
@@ -415,6 +438,15 @@
         const noteButtonsDiv = document.getElementById("noteButtons");
         const submitBtn = document.getElementById("submitBtn");
         const playTargetBtn = document.getElementById("playTargetBtn");
+        const gameAreaMessageEl = document.getElementById("gameAreaMessage");
+        const motivationalMessages = [
+            "Level up! Your ears are locked in 🎯",
+            "New round, same main-character energy 😎",
+            "You got this — tiny notes, giant wins!",
+            "Brain warmed up? Let’s make this melody cry.",
+            "No panic, just rhythm. Keep going!"
+        ];
+        let levelMessageTimeout;
 
         // Update primary status (without affecting the large level indicator)
         function updateStatusDisplay() {
@@ -430,6 +462,20 @@
             setTimeout(() => {
                 compositionLevelEl.style.display = "none";
             }, 500);
+        }
+
+        function updateSubmitVisibility() {
+            submitBtn.style.display = playerSequence.length === 0 ? "none" : "inline-block";
+        }
+
+        function showLevelMessage() {
+            const phrase = motivationalMessages[Math.floor(Math.random() * motivationalMessages.length)];
+            gameAreaMessageEl.textContent = phrase;
+            gameAreaMessageEl.classList.add("visible");
+            clearTimeout(levelMessageTimeout);
+            levelMessageTimeout = setTimeout(() => {
+                gameAreaMessageEl.classList.remove("visible");
+            }, 1800);
         }
 
         // Update the target melody button text with remaining replays.
@@ -451,6 +497,7 @@
                 });
                 playerPanel.appendChild(span);
             });
+            updateSubmitVisibility();
         }
 
         // Create a ripple effect originating from where the note button is clicked.
@@ -512,10 +559,12 @@
                 targetSequence.push(availableNotes[randomIndex]);
             }
         }
-        function setupLevel() {
+        function setupLevel(resetLives = false) {
             // Reset level parameters.
             compositionLength = baseCompositionLength + currentLevel - 1;
-            lives = 3;
+            if (resetLives) {
+                lives = startingLives;
+            }
             playerSequence = [];
             remainingReplays = baseReplays + (currentLevel - 1);
             // Clear guess history between levels.
@@ -528,6 +577,7 @@
             updateTargetReplayDisplay();
             feedbackEl.textContent = "";
             submitBtn.disabled = false;
+            showLevelMessage();
         }
         function nextLevel() {
             currentLevel++;
@@ -659,7 +709,7 @@
             totalNotesAttempted = 0;
             // Reset level and game state.
             currentLevel = 1;
-            setupLevel();
+            setupLevel(true);
         });
 
         // Event listener for "Play Target Melody" button.
@@ -698,7 +748,7 @@
         /***************************************
          * Initialize the Game                 *
          ***************************************/
-        setupLevel();
+        setupLevel(true);
     </script>
     <link rel="stylesheet" href="/globalNav/globalNav.css">
     <script type="module" src="/globalNav/globalNav.js" defer></script>


### PR DESCRIPTION
### Motivation
- Improve the Seequence/Heardle play flow by keeping players engaged between levels with short motivational messages and clearer pacing.  
- Make the primary start/play control part of the game area so it’s more discoverable during play.  
- Provide a consistent 3-life run mechanic so lives persist across level retries and only reset on a fresh game.  
- Reduce UI clutter by hiding the submit action while the composition area is empty.

### Description
- Added an in-area temporary message overlay `#gameAreaMessage` and a small `motivationalMessages` array with `showLevelMessage()` to display a random encouragement for ~1.8s on level transitions.  
- Moved the start/play control into the composition area and updated the button text to `Start / Play Target Melody` (`#playTargetBtn`).  
- Introduced `startingLives = 3` and updated `setupLevel(resetLives = false)` so lives are only reset when `resetLives` is true (initial start / `Play Again`), preserving lives across intermediate level retries.  
- Hid the submit button when there are no notes via `updateSubmitVisibility()` and call it from `updatePlayerPanel()` so `#submitBtn` only appears once the player has added notes.  
- Minor CSS and layout changes to position the message overlay and keep the composition area `position: relative` so messages appear above the game content (changes in `heardle/index.html`).

### Testing
- Launched a local web server with `python3 -m http.server` to serve the updated `heardle/index.html`, which started successfully.  
- Attempted an automated Playwright screenshot of `http://127.0.0.1:8000/heardle/index.html`, but the Chromium process crashed with a `SIGSEGV` in this environment so the headless browser test failed; code and layout were otherwise inspected in-place.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699e17561adc83318c5f72eddeb1ef71)