### PR TITLE
Polish Werdle feedback loop with streaks and richer UX

### DIFF
--- a/game/nerdle.css
+++ b/game/nerdle.css
@@ -180,3 +180,105 @@ html {
         transform: translateY(0px);
     }
 }
+
+.statsRow {
+    display: flex;
+    justify-content: center;
+    gap: 10px;
+    margin: 8px auto 4px;
+}
+
+.statBox {
+    background: #ffffff12;
+    border: 1px solid #ffffff2f;
+    border-radius: 10px;
+    padding: 6px 10px;
+    min-width: 62px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.statBox span {
+    font-size: 20px;
+    font-weight: bold;
+    line-height: 1;
+}
+
+.statBox small {
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    opacity: 0.8;
+}
+
+.attemptMeter {
+    display: flex;
+    justify-content: center;
+    gap: 6px;
+    margin: 8px 0;
+}
+
+.attemptDot {
+    width: 10px;
+    height: 10px;
+    border-radius: 999px;
+    background: #ffffff24;
+    transition: transform 0.2s ease, background 0.2s ease;
+}
+
+.attemptDot.used {
+    background: #85d5ff;
+    transform: scale(1.2);
+}
+
+.statusText {
+    min-height: 20px;
+    margin: 4px 0 10px;
+    font-size: 14px;
+    color: #cde8f6;
+}
+
+.statusText.success {
+    color: #c8ffd6;
+}
+
+.statusText.warning {
+    color: #ffe7a0;
+}
+
+.statusText.danger {
+    color: #ffc2c2;
+}
+
+.inputPulse {
+    animation: pulse 0.22s linear 2;
+}
+
+.effects {
+    pointer-events: none;
+    position: fixed;
+    inset: 0;
+    overflow: hidden;
+}
+
+.confetti {
+    position: absolute;
+    top: -20px;
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    animation: fall 1.8s linear forwards;
+}
+
+@keyframes fall {
+    to {
+        transform: translateY(100vh) rotate(720deg);
+        opacity: 0;
+    }
+}
+
+@keyframes pulse {
+    0% { transform: scale(1); }
+    50% { transform: scale(1.03); }
+    100% { transform: scale(1); }
+}

--- a/game/nerdle.html
+++ b/game/nerdle.html
@@ -28,6 +28,14 @@
 
     <div id="content" class="content">
         <h1>WERDLE</h1>
+        <div class="statsRow">
+            <div class="statBox"><span id="streakCount">0</span><small>streak</small></div>
+            <div class="statBox"><span id="bestStreakCount">0</span><small>best</small></div>
+            <div class="statBox"><span id="attemptsLeft">5</span><small>left</small></div>
+        </div>
+
+        <div id="attemptMeter" class="attemptMeter"></div>
+        <div id="statusText" class="statusText">Warm up round. Type a 5-letter word.</div>
 
         <input type="text" onkeypress="enterSubmit(event)" onsubmit="gameAttempt()" id="userInput" placeholder="guess"
             style="margin-top: 10px; margin-bottom: 10px; height: 16px;"></input>
@@ -54,6 +62,7 @@
             text-align: center; 
             white-space: nowrap;">Incorrect letters will show
             here</div>
+        <div id="effects" class="effects" aria-hidden="true"></div>
 
 </body>
 

--- a/game/nerdle.js
+++ b/game/nerdle.js
@@ -7,167 +7,199 @@ correctList = [];
 possibleList = ["q", "w", "e", "r", "t", "y"
     , "u", "i", "o", "p", "a", "s", "d", "f", "g", "h", "j", "k", "l", "z", "x", "c", "v", "b"
     , "n", "m"];
-possibleList2 = ["q", "w", "e", "r", "t", "y", "u", "i", "o", "p", "a", "s", "d"
-    , "f", "g", "h", "j", "k", "l", "z", "x", "c", "v", "b", "n", "m"];
 secret = (wordlist[Math.floor(Math.random() * wordlist.length)].toLowerCase());
 guess = "";
 guessNumber = 0;
+currentStreak = Number(localStorage.getItem("werdleStreak") || 0);
+bestStreak = Number(localStorage.getItem("werdleBestStreak") || 0);
 var def;
 
 function reset() {
-    secret = (wordlist[Math.floor(Math.random() * wordlist.length)].toLowerCase())
-    guess = ""
-    guessNumber = 0
-    incorrectList = []
-    placedList = []
-    correctList = []
-    def = ""
+    secret = (wordlist[Math.floor(Math.random() * wordlist.length)].toLowerCase());
+    guess = "";
+    guessNumber = 0;
+    incorrectList = [];
+    placedList = [];
+    correctList = [];
+    def = "";
+    $('#definition').html('');
+    $('#incorrectArea').html("Incorrect letters: none");
+    renderAttempts();
+    updateKeyboard();
+    updateStats();
 }
 
-window.onload = function () { 
-    resetKeyboard(); 
-    $('#userInput').focus();
-    if(localStorage.getItem("revisit")=="true"){
-        x=document.getElementById('welcome')
-        x.style.display="none"
-        $('#bottomPortion').css("display", "block"); 
+window.onload = function () {
+    if (localStorage.getItem("revisit") == "true") {
+        const x = document.getElementById('welcome');
+        x.style.display = "none";
+        $('#bottomPortion').css("display", "block");
     }
-
+    reset();
+    $('#userInput').focus();
+    status('Warm up round. Type a 5-letter word.');
 }
-
-
 
 function enterSubmit(e) { if (e.which == 13) { gameAttempt() } }
+
+function status(message, tone) {
+    const el = $('#statusText');
+    el.removeClass('success warning danger');
+    if (tone) {
+        el.addClass(tone);
+    }
+    el.text(message);
+}
+
+function renderAttempts() {
+    $('#attemptsLeft').text(5 - guessNumber);
+    const meter = $('#attemptMeter');
+    meter.html('');
+    for (let i = 0; i < 5; i++) {
+        meter.append('<div class="attemptDot ' + (i < guessNumber ? 'used' : '') + '"></div>');
+    }
+}
+
+function updateStats() {
+    $('#streakCount').text(currentStreak);
+    $('#bestStreakCount').text(bestStreak);
+}
+
+function celebrate() {
+    const colours = ['#9fffcb', '#85d5ff', '#f8ff99', '#ffc6ea', '#ffd3a1'];
+    const root = $('#effects');
+    for (let i = 0; i < 24; i++) {
+        const left = Math.floor(Math.random() * 100);
+        const c = colours[Math.floor(Math.random() * colours.length)];
+        const delay = Math.random() * 0.3;
+        const size = 6 + Math.random() * 8;
+        root.append('<div class="confetti" style="left:' + left + '%;background:' + c + ';animation-delay:' + delay + 's;width:' + size + 'px;height:' + size + 'px;"></div>');
+    }
+    setTimeout(() => root.html(''), 2200);
+    if (navigator.vibrate) {
+        navigator.vibrate([80, 60, 120]);
+    }
+}
+
+function addInputPulse() {
+    const input = $('#userInput');
+    input.addClass('inputPulse');
+    setTimeout(() => input.removeClass('inputPulse'), 450);
+}
+
 function gameAttempt() {
-    if (guess != secret && guessNumber < 5) {
-        guess = $('#userInput').val().toLowerCase()
-        if (guess.length == 5) {
-            check(guess)
-            if (guessNumber == 0) {
-                $('#gameText').html("")
-            } guessNumber += 1
-            if (guess == secret) {
-                //display the winning word (all green)
-                for (var i = 0; i < guess.length; i++) {
-                    $('#gameText').append('<div class= "letter green winning" style="animation-delay:' + (i / 10) + 's" > ' + guess[i] + '</div >')
-                }
-                $('#gameText').append("<div class='Winner'>Winner Winner</div > ")
-                $('#gameText').append("<div>Game Over.... the word was '" + secret + "'</div><br><br>Play again by guessing the next word")
+    if (guess == secret || guessNumber >= 5) {
+        return;
+    }
 
+    guess = $('#userInput').val().toLowerCase().trim();
 
-                reset()
+    if (guess.length != 5) {
+        status('Need exactly 5 letters.', 'warning');
+        addInputPulse();
+        return;
+    }
 
+    check(guess);
+    if (guessNumber == 0) {
+        $('#gameText').html("");
+    }
+
+    let exactMatches = 0;
+    for (var i = 0; i < guess.length; i++) {
+        if (secret.includes(guess[i])) {
+            if (guess[i] == secret[i]) {
+                $('#gameText').append('<div class="letter green">' + guess[i] + '</div>');
+                correctList.push(guess[i]);
+                exactMatches += 1;
             }
             else {
-               
-                //display guess with correct colours
-                for (var i = 0; i < guess.length; i++) {
-
-                    if (secret.includes(guess[i])) {
-                        if (guess[i] == secret[i]) {
-                            $('#gameText').append('<div class="letter green">' + guess[i] + '</div>')
-                            correctList.push(guess[i])
-                        }
-                        else {
-                            $('#gameText').append('<div class="letter blue">' + guess[i] + '</div>')
-                            placedList.push(guess[i])
-                        }
-                    }
-                    else {
-                        $('#gameText').append('<div class="letter black" style="color:black;">' + guess[i] + '</div>')
-                        incorrectList.push(guess[i])
-                    }
-
-                }
+                $('#gameText').append('<div class="letter blue">' + guess[i] + '</div>');
+                placedList.push(guess[i]);
             }
-            if (guessNumber == 5) {
-                $('#gameText').append("<div>Game Over.... the word was '" + secret + "'</div><br><br>Play again by guessing the next word")
-                reset()
-            }
-            //display updated keyboard - indexes in slices refer to the rows of a keyboard
-
-            $('#possibleArea').html('')
-
-            possibleList.forEach(i => {
-                //4 states are unguesses, guessed and placed, guessed anf exact and guessed and wrong
-                //placed
-                if (placedList.includes(i) && !correctList.includes(i)) {
-
-                    $('#possibleArea').append('<kbd onclick="addKey(event)" class="key" style="color:white; background:blue;">' + i
-                        + '</kbd>')
-                }
-                //exact
-                if (correctList.includes(i)) {
-
-                    $('#possibleArea').append('<kbd onclick="addKey(event)" class="key" style="color:white; background:green;">' + i
-                        + '</kbd>')
-                }
-                //guessed wrong
-                if (incorrectList.includes(i)) {
-
-                    $('#possibleArea').append('<kbd class="key" style="color:transparent; cursor:not-allowed">' + i
-                        + '</kbd>')
-                }
-                //not guessed
-                if (!incorrectList.includes(i) && !correctList.includes(i) && !placedList.includes(i)) {
-
-                    $('#possibleArea').append('<kbd onclick="addKey(event)" class="key" style="color:white; ">' + i
-                        + '</kbd>')
-                }
-                //break at the end of keyboard rows
-                if (i == "l" | i == "p") {
-                    $('#possibleArea').append('<br>')
-                }
-                if (i == "m") {
-                    $('#possibleArea').append('<kbd class="key" style="width: auto" onclick="gameAttempt()">Guess</kbd><br>')
-                }
-            })
-
-        } else {
-            alert("Invalid guess length. Try again.")
         }
-        $('#gameText').append('</br>')
-        $('#gameText').append('</div>')
-        $('#userInput').val('')
-        $('#userInput').focus()
-        $('#incorrectArea').html("Incorrect letters: " + incorrectList)
-
+        else {
+            $('#gameText').append('<div class="letter black" style="color:black;">' + guess[i] + '</div>');
+            incorrectList.push(guess[i]);
+        }
     }
 
+    guessNumber += 1;
+    renderAttempts();
+    updateKeyboard();
+
+    if (guess == secret) {
+        currentStreak += 1;
+        bestStreak = Math.max(bestStreak, currentStreak);
+        localStorage.setItem("werdleStreak", String(currentStreak));
+        localStorage.setItem("werdleBestStreak", String(bestStreak));
+        updateStats();
+        celebrate();
+        status('Huge win! +' + currentStreak + ' streak. New word loaded.', 'success');
+        $('#gameText').append("<div class='Winner'>Winner Winner</div>");
+        $('#gameText').append("<div>Game Over.... the word was '" + secret + "'</div><br><br>Play again by guessing the next word");
+        reset();
+    } else if (guessNumber == 5) {
+        currentStreak = 0;
+        localStorage.setItem("werdleStreak", "0");
+        updateStats();
+        status("Close one. Streak reset — next word is live.", 'danger');
+        $('#gameText').append("<div>Game Over.... the word was '" + secret + "'</div><br><br>Play again by guessing the next word");
+        reset();
+    } else if (exactMatches >= 4) {
+        status('So close. One letter away 🔥', 'warning');
+    } else {
+        status('Good probe. Keep the momentum going.');
+    }
+
+    $('#gameText').append('</br>');
+    $('#gameText').append('</div>');
+    $('#userInput').val('');
+    $('#userInput').focus();
+    $('#incorrectArea').html("Incorrect letters: " + [...new Set(incorrectList)].join(', '));
 }
 
-function resetKeyboard() {
-    $('#possibleArea').html('')
+function updateKeyboard() {
+    $('#possibleArea').html('');
     possibleList.forEach(i => {
-        $('#possibleArea').append('<kbd onclick="addKey(event)" class="key">' + i + '</kbd>')
-        if (i == "p" | i == "l") {
-            $('#possibleArea').append('<br>')
+        if (placedList.includes(i) && !correctList.includes(i)) {
+            $('#possibleArea').append('<kbd onclick="addKey(event)" class="key" style="color:white; background:blue;">' + i + '</kbd>');
+        }
+        if (correctList.includes(i)) {
+            $('#possibleArea').append('<kbd onclick="addKey(event)" class="key" style="color:white; background:green;">' + i + '</kbd>');
+        }
+        if (incorrectList.includes(i)) {
+            $('#possibleArea').append('<kbd class="key" style="color:transparent; cursor:not-allowed">' + i + '</kbd>');
+        }
+        if (!incorrectList.includes(i) && !correctList.includes(i) && !placedList.includes(i)) {
+            $('#possibleArea').append('<kbd onclick="addKey(event)" class="key" style="color:white;">' + i + '</kbd>');
+        }
+        if (i == "l" || i == "p") {
+            $('#possibleArea').append('<br>');
         }
         if (i == "m") {
-            $('#possibleArea').append('<kbd class="key" style="width: auto" onclick="gameAttempt()">Guess</kbd><br>')
+            $('#possibleArea').append('<kbd class="key" style="width: auto" onclick="gameAttempt()">Guess</kbd><br>');
         }
-    }
-    )
+    })
 }
+
 function addKey(e) {
-    if (guessNumber == 5) {
-        $('#gameText').innerHTML = ""
-    }
     if ($('#userInput').val().length == 5) {
-        alert("max length reached - 5 letter words only")
+        status('Max length reached (5). Hit Guess.', 'warning');
+        addInputPulse();
     }
     else {
-        current = $('#userInput').val()
-        $('#userInput').val(current + e.target.innerHTML)
+        const current = $('#userInput').val();
+        $('#userInput').val(current + e.target.innerHTML);
     }
-    $('#userInput').focus()
+    $('#userInput').focus();
 }
 
 function closeWelcome() {
-    localStorage.setItem("revisit", "true")
+    localStorage.setItem("revisit", "true");
     if ($('#welcome').css("display") == "none") {
         $('#welcome').css("display", "block"); $('#bottomPortion').css("display", "none");
-        
+
     }
     else { $('#welcome').css("display", "none"); $('#bottomPortion').css("display", "block"); }
     $('#userInput').focus();


### PR DESCRIPTION
### Motivation
- Improve moment-to-moment feedback and player momentum so each guess feels meaningful and rewarding.
- Add lightweight progression (streaks/attempts) and celebration cues to create more dopamine-rich moments on success.

### Description
- Added a small HUD to `game/nerdle.html` with current streak, best streak, attempts-left, an `#attemptMeter` and a `#statusText` area for dynamic turn messages.
- Implemented UI/UX logic in `game/nerdle.js` to persist `currentStreak` and `bestStreak` to `localStorage`, update an attempt meter, show status tones (`success`, `warning`, `danger`), give input pulse feedback on invalid input, and trigger a `celebrate()` routine (confetti + vibration) on wins.
- Centralised keyboard and incorrect-letter rendering in `updateKeyboard()` and improved incorrect-letter display to deduplicate entries; preserved the existing dictionary lookup behavior in `check()`.
- Added supporting styles and animations to `game/nerdle.css` for stat cards, attempt dots, status colors, input pulse, and confetti fall effect, plus an `#effects` container for celebrations.

### Testing
- `node --check game/nerdle.js` — syntax check passed after fixes.
- Served the site with `python3 -m http.server 4173 --directory /workspace/playnerdle` and exercised the UI via an automated Playwright script which successfully loaded the page and captured a screenshot (`artifacts/werdle-polish.png`).
- The automated checks above completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af171c83a08331af0d0146bf12a5d4)