### PR TITLE
Add calming animated backgrounds to Codle and Bludle

### DIFF
--- a/bludle/bludle.css
+++ b/bludle/bludle.css
@@ -10,6 +10,46 @@ body {
     text-align: center;
 }
 
+html {
+    min-height: 100%;
+    background: linear-gradient(140deg, #f8fbff, #eaf3ff, #e4eaff);
+    background-size: 220% 220%;
+    animation: bludleSkyShift 30s ease-in-out infinite;
+}
+
+body {
+    position: relative;
+    isolation: isolate;
+}
+
+body::before,
+body::after {
+    content: '';
+    position: fixed;
+    z-index: -1;
+    border-radius: 50%;
+    pointer-events: none;
+    filter: blur(2px);
+}
+
+body::before {
+    width: 36vmax;
+    height: 36vmax;
+    top: -10vmax;
+    left: -8vmax;
+    background: radial-gradient(circle, rgba(108, 146, 255, 0.2) 0%, rgba(108, 146, 255, 0) 70%);
+    animation: bludleDrift 36s ease-in-out infinite alternate;
+}
+
+body::after {
+    width: 28vmax;
+    height: 28vmax;
+    right: -8vmax;
+    bottom: -10vmax;
+    background: radial-gradient(circle, rgba(120, 216, 255, 0.22) 0%, rgba(120, 216, 255, 0) 68%);
+    animation: bludleDrift 44s ease-in-out infinite alternate-reverse;
+}
+
 .titleArea {
     margin-top: 10px;
 }
@@ -239,7 +279,7 @@ body {
 }
 
 @media only screen and (max-width: 550px) {
-  
+
     #content {
         width: 90vw
     }
@@ -321,5 +361,34 @@ body {
 @media only screen and (max-width: 550px) {
     .resourceGrid {
         grid-template-columns: 1fr;
+    }
+}
+
+@keyframes bludleSkyShift {
+    0% {
+        background-position: 0% 50%;
+    }
+    50% {
+        background-position: 100% 50%;
+    }
+    100% {
+        background-position: 0% 50%;
+    }
+}
+
+@keyframes bludleDrift {
+    0% {
+        transform: translate3d(0, 0, 0) scale(1);
+    }
+    100% {
+        transform: translate3d(6vmax, 4vmax, 0) scale(1.12);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html,
+    body::before,
+    body::after {
+        animation: none;
     }
 }

--- a/codle/codle.css
+++ b/codle/codle.css
@@ -2,21 +2,53 @@
     font-family: 'Roboto Condensed', sans-serif !important;
     font-weight: normal !important;
     text-decoration: none;
-   
+
 }
 
 html {
     position: relative;
-   
     margin: 0;
     padding: 0;
-    background: linear-gradient(to right, #0f2027, #203a43, #2c5364);
+    min-height: 100%;
+    background: linear-gradient(120deg, #0f2027, #203a43, #2c5364);
+    background-size: 180% 180%;
+    animation: codleGradientShift 28s ease-in-out infinite;
 }
 
 body {
+    position: relative;
+    isolation: isolate;
     padding: 0;
     margin: 0;
     padding-top: 50px;
+}
+
+body::before,
+body::after {
+    content: '';
+    position: fixed;
+    z-index: -1;
+    width: 45vmax;
+    height: 45vmax;
+    border-radius: 50%;
+    opacity: 0.2;
+    filter: blur(6px);
+    pointer-events: none;
+    animation: codleFloat 32s ease-in-out infinite alternate;
+}
+
+body::before {
+    background: radial-gradient(circle, rgba(59, 246, 184, 0.55) 0%, rgba(59, 246, 184, 0) 68%);
+    top: -8vmax;
+    left: -10vmax;
+}
+
+body::after {
+    background: radial-gradient(circle, rgba(0, 154, 255, 0.45) 0%, rgba(0, 154, 255, 0) 65%);
+    right: -12vmax;
+    bottom: -14vmax;
+    animation-duration: 38s;
+    animation-direction: alternate-reverse;
 }
 
 h1 {
@@ -264,4 +296,32 @@ p {
     margin-left: 50%;
     transform: translatex(-50%);
     margin-top: 10px;
+}
+@keyframes codleGradientShift {
+    0% {
+        background-position: 0% 50%;
+    }
+    50% {
+        background-position: 100% 50%;
+    }
+    100% {
+        background-position: 0% 50%;
+    }
+}
+
+@keyframes codleFloat {
+    0% {
+        transform: translate3d(0, 0, 0) scale(1);
+    }
+    100% {
+        transform: translate3d(7vmax, 5vmax, 0) scale(1.18);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    html,
+    body::before,
+    body::after {
+        animation: none;
+    }
 }


### PR DESCRIPTION
### Motivation
- Provide a slow, calming ambient background for gameplay pages to make the experience more relaxing through subtle motion and color transitions.

### Description
- Updated `codle/codle.css` to animate the page gradient (`codleGradientShift`) and add two soft, drifting radial blobs via `body::before` and `body::after` with `codleFloat` keyframes and `background-size` adjustments.
- Updated `bludle/bludle.css` to add a soft sky-gradient animation (`bludleSkyShift`) and two gentle drifting radial shapes via `body::before` and `body::after` with `bludleDrift` keyframes.
- Added `@media (prefers-reduced-motion: reduce)` handling to disable animations for users who opt out, and applied `isolation: isolate`/fixed positioning to keep background layers visually behind page content.

### Testing
- Served the site locally with `python3 -m http.server 4173` and confirmed pages load successfully (passed).
- Ran an automated Playwright script to load `/codle/index.html` and `/bludle/index.html` and capture screenshots of the updated pages (screenshots captured successfully).
- Ran `git diff --check` to validate whitespace and style issues (no errors reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c978867c83318b92fcb0d2f554eb)