### PR TITLE
Add click animations, spark effects and refactor grid squares

### DIFF
--- a/guesshue/index.html
+++ b/guesshue/index.html
@@ -23,6 +23,79 @@
       grid-gap: 5px;
     }
 
+    .grid-square {
+      width: 100px;
+      height: 100px;
+      display: inline-block;
+      cursor: pointer;
+      transition: transform 0.12s ease;
+    }
+
+    .grid-square:active {
+      transform: scale(0.97);
+    }
+
+    .grid-square.correct-click {
+      animation: pop-correct 0.18s ease-out;
+    }
+
+    .grid-square.wrong-click {
+      animation: shake-wrong 0.2s ease-in-out;
+    }
+
+    @keyframes pop-correct {
+      0% {
+        transform: scale(0.96);
+      }
+
+      60% {
+        transform: scale(1.05);
+      }
+
+      100% {
+        transform: scale(1);
+      }
+    }
+
+    @keyframes shake-wrong {
+      0%,
+      100% {
+        transform: translateX(0);
+      }
+
+      25% {
+        transform: translateX(-5px);
+      }
+
+      75% {
+        transform: translateX(5px);
+      }
+    }
+
+
+    .spark {
+      position: fixed;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      pointer-events: none;
+      transform: translate(-50%, -50%);
+      animation: spark-burst 420ms ease-out forwards;
+      z-index: 1000;
+    }
+
+    @keyframes spark-burst {
+      0% {
+        opacity: 1;
+        transform: translate(-50%, -50%) scale(1);
+      }
+
+      100% {
+        opacity: 0;
+        transform: translate(calc(-50% + var(--spark-x)), calc(-50% + var(--spark-y))) scale(0.35);
+      }
+    }
+
     #timer {
       width: 100%;
       height: 20px;
@@ -267,12 +340,9 @@
 
       for (let i = 0; i < 9; i++) {
         const square = document.createElement("div");
-        square.style.width = "100px";
-        square.style.height = "100px";
-        square.style.display = "inline-block";
-        square.style.cursor = "pointer";
+        square.className = "grid-square";
         square.style.backgroundColor = i === oddPosition ? oddColor : mainColor;
-        square.addEventListener("click", () => checkSquare(i));
+        square.addEventListener("click", (event) => checkSquare(i, square, event));
         container.appendChild(square);
       }
       startTime = Date.now();
@@ -309,18 +379,44 @@
 
     document.getElementById("restartButton").addEventListener("click", restartGame);
 
-    const checkSquare = (index) => {
+
+    const createCartoonySparks = (event, color) => {
+      const sparkCount = 6;
+
+      for (let i = 0; i < sparkCount; i++) {
+        const spark = document.createElement("span");
+        spark.className = "spark";
+        spark.style.backgroundColor = color;
+
+        const angle = (Math.PI * 2 * i) / sparkCount + (Math.random() * 0.35);
+        const distance = 12 + Math.random() * 18;
+        spark.style.setProperty("--spark-x", `${Math.cos(angle) * distance}px`);
+        spark.style.setProperty("--spark-y", `${Math.sin(angle) * distance}px`);
+        spark.style.left = `${event.clientX}px`;
+        spark.style.top = `${event.clientY}px`;
+
+        document.body.appendChild(spark);
+        spark.addEventListener("animationend", () => spark.remove(), { once: true });
+      }
+    };
+
+    const checkSquare = (index, squareElement, event) => {
       const endTime = Date.now();
       const timeTaken = (endTime - startTime) / 1000;
+      clearInterval(timer);
 
       if (index === oddPosition) {
+        squareElement.classList.add("correct-click");
+        createCartoonySparks(event, "#fff275");
         roundTimes.push(timeTaken);
         slowestTime = Math.max(slowestTime, timeTaken);
         streak++;
         updateStreakDisplay();
-        initGameBoard();
+        setTimeout(initGameBoard, 120);
       } else {
-        showGameOver();
+        squareElement.classList.add("wrong-click");
+        createCartoonySparks(event, "#ff7a7a");
+        setTimeout(showGameOver, 140);
       }
     };
 


### PR DESCRIPTION
### Motivation
- Improve user feedback and polish the game's UX by adding visual click animations and spark effects on correct/wrong taps.
- Simplify DOM styling by moving repeated inline styles into a reusable CSS class to make the board generation code cleaner.

### Description
- Added a `.grid-square` CSS class and keyframe animations `pop-correct` and `shake-wrong` and applied them for correct and wrong clicks respectively.
- Introduced a `.spark` element and `spark-burst` animation plus the `createCartoonySparks` function to spawn short-lived spark particles at the click position.
- Refactored `initGameBoard` to assign `className = "grid-square"` instead of inline styles and to pass the clicked element and event into `checkSquare` via `addEventListener`.
- Updated `checkSquare` signature to `(index, squareElement, event)`, clear the timer on click, add/remove animations on the clicked square, and delay `initGameBoard`/`showGameOver` briefly to let animations run.

### Testing
- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d3b679b88331b93bbcba7a4106c0)