### PR TITLE
Fix GuessHue click handler regression after conflict resolution

### DIFF
--- a/guesshue/index.html
+++ b/guesshue/index.html
@@ -343,7 +343,6 @@
         square.className = "grid-square";
         square.style.backgroundColor = i === oddPosition ? oddColor : mainColor;
         square.addEventListener("click", (event) => checkSquare(i, square, event));
-        square.addEventListener("click", () => checkSquare(i, square));
         container.appendChild(square);
       }
       startTime = Date.now();
@@ -402,7 +401,6 @@
     };
 
     const checkSquare = (index, squareElement, event) => {
-    const checkSquare = (index, squareElement) => {
       const endTime = Date.now();
       const timeTaken = (endTime - startTime) / 1000;
       clearInterval(timer);


### PR DESCRIPTION
### Motivation
- Resolve a merge-induced regression in `guesshue/index.html` where duplicate click bindings and a duplicated `checkSquare` declaration caused double handler execution and broke access to the click `event` used for spark effects.

### Description
- Remove the duplicate `click` event listener and the accidental duplicate `checkSquare` declaration, keeping the single handler signature `checkSquare(index, squareElement, event)` so clicks are handled once and the spark placement works.

### Testing
- Ran `rg -n "const checkSquare|addEventListener(\"click\"" guesshue/index.html`, `git diff --check`, and `git status --short` to validate the fix and there were no issues; the checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5d8e5bbb88331b24f9c3532a441ee)