### PR TITLE
Connex: add ambient background and micro-animations

### DIFF
--- a/connex/index.html
+++ b/connex/index.html
@@ -10,11 +10,41 @@
     <style>
         body {
             font-family: Arial, sans-serif;
-            background-color: #121212;
+            background: radial-gradient(circle at 20% 20%, #173026 0%, #111 40%, #090909 100%);
             color: white;
             text-align: center;
             padding: 20px;
             margin-top: 40px;
+            min-height: 100vh;
+            overflow-x: hidden;
+            position: relative;
+        }
+
+        body::before,
+        body::after {
+            content: "";
+            position: fixed;
+            width: 320px;
+            height: 320px;
+            border-radius: 50%;
+            filter: blur(50px);
+            opacity: 0.2;
+            z-index: -1;
+            pointer-events: none;
+            animation: floatGlow 14s ease-in-out infinite;
+        }
+
+        body::before {
+            background: #00b96b;
+            top: 6vh;
+            left: -80px;
+        }
+
+        body::after {
+            background: #3b7cff;
+            right: -100px;
+            bottom: 8vh;
+            animation-delay: -7s;
         }
 
         h1 {
@@ -27,6 +57,7 @@
             gap: 10px;
             margin: 0 auto 20px auto;
             max-width: 600px;
+            perspective: 1000px;
         }
 
         .word-item {
@@ -37,6 +68,10 @@
             cursor: pointer;
             transition: background-color 0.3s ease;
             -webkit-tap-highlight-color: transparent;
+            transform: translateY(14px) scale(0.97);
+            opacity: 0;
+            animation: cardIn 0.35s ease forwards;
+            animation-delay: calc(var(--stagger-index, 0) * 40ms);
         }
 
         .word-item.selected {
@@ -46,6 +81,7 @@
         .word-item.correct {
             background-color: #007a3e;
             pointer-events: none;
+            animation: solvedPulse 400ms ease;
         }
 
         .word-item:hover {
@@ -60,6 +96,11 @@
             margin-top: 20px;
             font-size: 24px;
             color: #f00;
+            min-height: 30px;
+        }
+
+        .feedback.error {
+            animation: nudge 320ms ease;
         }
 
         .lives {
@@ -81,6 +122,67 @@
             border-radius: 5px;
             width: 100%;
             text-align: center;
+            animation: cardIn 0.45s ease;
+        }
+
+        @keyframes cardIn {
+            from {
+                opacity: 0;
+                transform: translateY(14px) scale(0.97);
+            }
+
+            to {
+                opacity: 1;
+                transform: translateY(0) scale(1);
+            }
+        }
+
+        @keyframes solvedPulse {
+            0% {
+                transform: scale(1);
+            }
+
+            50% {
+                transform: scale(1.06);
+            }
+
+            100% {
+                transform: scale(1);
+            }
+        }
+
+        @keyframes nudge {
+            0%,
+            100% {
+                transform: translateX(0);
+            }
+
+            25% {
+                transform: translateX(-6px);
+            }
+
+            75% {
+                transform: translateX(6px);
+            }
+        }
+
+        @keyframes floatGlow {
+            0%,
+            100% {
+                transform: translate(0, 0);
+            }
+
+            50% {
+                transform: translate(18px, -24px);
+            }
+        }
+
+        @media (prefers-reduced-motion: reduce) {
+            * {
+                animation-duration: 0.01ms !important;
+                animation-iteration-count: 1 !important;
+                transition-duration: 0.01ms !important;
+            }
         }
 
         .group-items-wrapper {
@@ -1020,6 +1122,7 @@
                 wordItem.classList.add('word-item');
                 wordItem.textContent = word;
                 wordItem.addEventListener('click', () => handleWordClick(wordItem));
+                wordItem.style.setProperty('--stagger-index', currentWords.indexOf(word));
                 wordListDiv.appendChild(wordItem);
             });
         };
@@ -1042,8 +1145,12 @@
             );
 
             if (groupsSelected.length !== 1) {
-                document.getElementById('feedback').textContent = 'Oops! Incorrect guess.';
-                document.getElementById('feedback').style.color = '#f00';
+                const feedbackElement = document.getElementById('feedback');
+                feedbackElement.textContent = 'Oops! Incorrect guess.';
+                feedbackElement.style.color = '#f00';
+                feedbackElement.classList.remove('error');
+                void feedbackElement.offsetWidth;
+                feedbackElement.classList.add('error');
                 lives--;
                 updateLives();
 
@@ -1060,8 +1167,10 @@
             } else {
                 let groupIndex = correctAnswerBanks.indexOf(groupsSelected[0]);
                 selectedItems.forEach(item => item.classList.add('correct'));
-                document.getElementById('feedback').textContent = `Correct! Connection: ${correctAnswerBanks[groupIndex].connectionReason}`;
-                document.getElementById('feedback').style.color = '#00b96b';
+                const feedbackElement = document.getElementById('feedback');
+                feedbackElement.textContent = `Correct! Connection: ${correctAnswerBanks[groupIndex].connectionReason}`;
+                feedbackElement.style.color = '#00b96b';
+                feedbackElement.classList.remove('error');
                 moveToTop(selectedItems);
 
                 const groupDiv = document.createElement('div');


### PR DESCRIPTION
### Motivation
- Make the Connex page feel more polished and lively by adding subtle ambient background effects and small interaction animations. 
- Improve feedback clarity for correct/incorrect guesses and make the UI feel more responsive without changing core gameplay.
- Respect accessibility preferences by providing reduced-motion fallbacks.

### Description
- Replaced the flat page background with a radial gradient and two softly animated glow orbs using `body::before` and `body::after` to create ambient lighting. 
- Added CSS micro-animations: `cardIn` (tile/group entrance), `solvedPulse` (correct tile pulse), `nudge` (incorrect-guess shake), and `floatGlow` (orb movement), plus `prefers-reduced-motion` support. 
- Staggered tile entrance by setting a `--stagger-index` CSS variable from `renderWordList()` and animating tiles from an initial translate/opacity state into place. 
- Improved feedback area stability by adding `min-height` and toggling an `error` class (with a forced reflow) for repeatable incorrect-guess animation, and animated completed group cards. 
- Changes are confined to `connex/index.html` and include small JS updates to set the stagger index and manage feedback class toggling.

### Testing
- Launched a local static server and `curl` against `/connex/`, which returned HTTP 200, confirming the page serves successfully. (passed)
- Ran a headless Playwright script to load the page and capture a screenshot of the updated UI, producing an artifact image showing the new visuals. (passed)
- Verified the local server logs recorded successful requests to the page during the automated checks. (passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5dc12f75c8331bdab4b5a1c78dded)