### PR TITLE
Fix Connex final 4-word group being marked incorrect

### DIFF
--- a/connex/index.html
+++ b/connex/index.html
@@ -1101,13 +1101,15 @@
         let correctAnswerBanks = [];
         let lives = 5;
         let selectedGroups = [false, false, false, false];
+        let solvedBankIndexes = new Set();
         let completedGroups = 0;
 
         const getWordsForConnection = () => {
             const selectedBanks = selectRandomWordsFromBanks();
             currentWords = shuffle(selectedBanks.flatMap(bank => bank.words));
             correctAnswerBanks = selectedBanks;
-            selectedGroups = [false, false, false];
+            selectedGroups = [false, false, false, false];
+            solvedBankIndexes = new Set();
             completedGroups = 0;
             renderWordList();
             resetSelection();
@@ -1138,11 +1140,26 @@
 
         const checkAnswer = (selectedItems) => {
             const selectedWords = Array.from(selectedItems).map(el => el.textContent);
-            const selectedBanksWords = correctAnswerBanks.map(bank => bank.words);
+            const normalizedSelectedWords = selectedWords.map(word => word.toLowerCase());
 
-            const groupsSelected = correctAnswerBanks.filter(bank =>
-                selectedWords.every(word => bank.words.includes(word))
-            );
+            const unsolvedBankEntries = correctAnswerBanks
+                .map((bank, index) => ({ bank, index }))
+                .filter(({ index }) => !solvedBankIndexes.has(index));
+
+            const matchingGroups = unsolvedBankEntries.filter(({ bank }) => {
+                const normalizedBankWords = bank.words.map(word => word.toLowerCase());
+                return normalizedSelectedWords.every(word => normalizedBankWords.includes(word));
+            });
+
+            let groupsSelected = matchingGroups;
+
+            if (
+                groupsSelected.length === 0 &&
+                document.querySelectorAll('.word-item').length === 4 &&
+                unsolvedBankEntries.length === 1
+            ) {
+                groupsSelected = [unsolvedBankEntries[0]];
+            }
 
             if (groupsSelected.length !== 1) {
                 const feedbackElement = document.getElementById('feedback');
@@ -1165,7 +1182,8 @@
                     }, 500);
                 }
             } else {
-                let groupIndex = correctAnswerBanks.indexOf(groupsSelected[0]);
+                const groupIndex = groupsSelected[0].index;
+                solvedBankIndexes.add(groupIndex);
                 selectedItems.forEach(item => item.classList.add('correct'));
                 const feedbackElement = document.getElementById('feedback');
                 feedbackElement.textContent = `Correct! Connection: ${correctAnswerBanks[groupIndex].connectionReason}`;


### PR DESCRIPTION
### Motivation
- The Connex game sometimes marked the final four remaining correct words as incorrect because answer validation compared selections against all banks and was case-sensitive, causing false negatives late in the round.
- The goal is to ensure the validator only considers unsolved groups and accepts the final set when it is the only remaining unsolved bank.

### Description
- Track solved groups with a new `solvedBankIndexes` `Set` and mark a bank solved after a correct match via `solvedBankIndexes.add(index)`.
- Normalize comparisons by lowercasing words (`toLowerCase`) so capitalization differences do not break matching.
- Restrict matching to only unsolved banks by filtering `correctAnswerBanks` into `unsolvedBankEntries` before checking selections.
- Add a fallback that treats the last 4 remaining cards as a correct group when `document.querySelectorAll('.word-item').length === 4` and there is exactly one unsolved bank, and reset `solvedBankIndexes` at round start.

### Testing
- Launched a local static server with `python3 -m http.server 4173` and confirmed the Connex page served successfully (succeeded).
- Ran an automated Playwright script (via the run tool) which opened `http://127.0.0.1:4173/connex/` and produced a screenshot artifact to validate the page loaded after the change (succeeded).
- Performed a diff/inspection of `connex/index.html` to confirm the inserted logic and committed the change (verification via local diff succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5dfe1226083318116d328aab40f54)