### PR TITLE
Add Word Mash daily game with polished UI and homepage integration

### DIFF
--- a/globalNav/navLinks.js
+++ b/globalNav/navLinks.js
@@ -13,5 +13,6 @@ export const navLinks = [
     { name: "trak", href: "/trak" },
     { name: "tintuition", href: "/tintuition" },
     { name: "connex", href: "/connex" },
-    { name: "seequence", href: "/seequence" }
+    { name: "seequence", href: "/seequence" },
+    { name: "word mash", href: "/wordmash" }
 ];

--- a/home.js
+++ b/home.js
@@ -22,6 +22,7 @@ const tileHandlers = {
     alternate: () => trackClick('alternate'),
     connex: () => trackClick('connex'),
     heardle: () => trackClick('heardle'),
+    wordmash: () => trackClick('wordmash'),
 };
 
 window.addEventListener("DOMContentLoaded", () => {

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
   <meta name="description"
     content="Bludle is a free hub of daily and unlimited word games, logic puzzles, colour games and reaction challenges. Play Bludle, Werdle, Codle, Connex, Guess Hue and more in your browser." />
   <meta name="keywords"
-    content="word games, daily word game, free puzzle games, browser puzzle games, logic games, reaction game, colour games, nerdle alternatives, wordle alternatives, bludle, werdle, codle, connex" />
+    content="word games, daily word game, free puzzle games, browser puzzle games, logic games, reaction game, colour games, nerdle alternatives, wordle alternatives, bludle, werdle, codle, connex, word mash" />
   <meta name="robots" content="index, follow" />
   <link rel="canonical" href="https://www.bludle.com/" />
   <link rel="alternate" type="text/markdown" href="https://www.bludle.com/llms.txt" title="LLM site guide" />
@@ -84,6 +84,12 @@
           "position": 6,
           "name": "Guess Hue",
           "url": "https://www.bludle.com/guesshue/"
+        },
+        {
+          "@type": "ListItem",
+          "position": 7,
+          "name": "Word Mash",
+          "url": "https://www.bludle.com/wordmash/"
         }
       ]
     }
@@ -229,6 +235,14 @@
       </a>
     </div>
 
+    <div class="tile" id="wordmash">
+      <a class="game" href="/wordmash/" aria-label="Play Word Mash"
+        style="background-image: linear-gradient(140deg, #1f255c, #7c8dff 50%, #42e7f5)">
+        <div class="gameTitle">Word Mash</div>
+        <div class="gameInfo">Use two clues and overlap both answers into one mash word</div>
+      </a>
+    </div>
+
     <div class="tile" id="heardle">
       <a class="game" href="/heardle/" aria-label="Play Heardle" style="background-image: url('./images/heardle.png')">
         <div class="gameTitle">Heardle</div>
@@ -266,6 +280,7 @@
       <li><a href="/bludle/">Bludle</a> - decode a hidden word from shades of blue.</li>
       <li><a href="/codle/">Codle</a> - decode offset words with logic and pattern recognition.</li>
       <li><a href="/connex/">Connex</a> - find groups of related words by connection.</li>
+      <li><a href="/wordmash/">Word Mash</a> - solve two clues and blend the answers with an overlap.</li>
     </ul>
     <h3>Frequently asked questions</h3>
     <dl class="faq-list">
@@ -321,6 +336,7 @@
         <li><a href="/heardle" target="_blank">heardle</a></li>
         <li><a href="/connex" target="_blank">connex</a></li>
         <li><a href="/seequence" target="_blank">seequence</a></li>
+        <li><a href="/wordmash" target="_blank">word mash</a></li>
       </ul>
     </div>
   </footer>

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -22,6 +22,7 @@ Bludle is a free browser-based collection of daily and unlimited puzzle games, e
 - https://www.bludle.com/connex/
 - https://www.bludle.com/hunt/
 - https://www.bludle.com/seequence/
+- https://www.bludle.com/wordmash/
 
 ## Site index of notable games
 - https://www.bludle.com/alternate/

--- a/llms.txt
+++ b/llms.txt
@@ -16,6 +16,7 @@
 - Colour Match: https://www.bludle.com/colourmatch/
 - Tintuition: https://www.bludle.com/tintuition/
 - Seequence: https://www.bludle.com/seequence/
+- Word Mash (daily overlap blend puzzle): https://www.bludle.com/wordmash/
 
 ## Topic summary
 - Free word games online

--- a/wordmash/index.html
+++ b/wordmash/index.html
@@ -19,6 +19,19 @@
 <body>
   <div id="navbar-container"></div>
 
+  <div id="howto-overlay" class="modal-overlay" hidden>
+    <section class="modal" role="dialog" aria-modal="true" aria-labelledby="howto-title">
+      <h2 id="howto-title">How to play Word Mash</h2>
+      <ul>
+        <li>You get <strong>2 clues</strong> and up to <strong>6 guesses</strong>.</li>
+        <li>Work out both answers, then combine them into one word with overlap.</li>
+        <li>Example: <strong>star</strong> + <strong>artist</strong> = <strong>startist</strong>.</li>
+        <li>There is one puzzle per day and progress is saved in your browser.</li>
+      </ul>
+      <button type="button" id="dismiss-howto">Got it</button>
+    </section>
+  </div>
+
   <main class="page">
     <section class="hero">
       <p class="eyebrow">New Daily Game</p>
@@ -28,6 +41,7 @@
       <div class="badge-row">
         <span class="badge" id="puzzle-date">Daily puzzle</span>
         <span class="badge" id="streak-badge">Streak: 0</span>
+        <button class="badge button-badge" id="open-howto" type="button">How to play</button>
       </div>
     </section>
 
@@ -63,31 +77,10 @@
         <h2 id="result-title"></h2>
         <p id="result-message"></p>
         <div class="result-actions">
-          <button id="share-btn" type="button">Copy result</button>
-          <button id="next-day-btn" type="button" disabled>Next puzzle tomorrow</button>
+          <button id="share-btn" type="button">Share result</button>
         </div>
       </section>
     </section>
-
-    <aside class="ad-slot top-ad" aria-label="Advertisement placeholder">
-      <p>Ad placement area</p>
-      <small>Reserved for Google Ads top banner (responsive)</small>
-    </aside>
-
-    <section class="rules">
-      <h2>How to play</h2>
-      <ul>
-        <li>Solve both clues.</li>
-        <li>Merge the answers into one word where they overlap.</li>
-        <li>Example: <strong>star</strong> + <strong>artist</strong> = <strong>startist</strong>.</li>
-        <li>One puzzle per day. Your progress is saved in your browser.</li>
-      </ul>
-    </section>
-
-    <aside class="ad-slot bottom-ad" aria-label="Advertisement placeholder">
-      <p>Ad placement area</p>
-      <small>Reserved for Google Ads in-content rectangle</small>
-    </aside>
   </main>
 </body>
 

--- a/wordmash/index.html
+++ b/wordmash/index.html
@@ -19,7 +19,7 @@
 <body>
   <div id="navbar-container"></div>
 
-  <div id="howto-overlay" class="modal-overlay" hidden>
+  <div id="howto-overlay" class="modal-overlay" aria-hidden="true">
     <section class="modal" role="dialog" aria-modal="true" aria-labelledby="howto-title">
       <h2 id="howto-title">How to play Word Mash</h2>
       <ul>

--- a/wordmash/index.html
+++ b/wordmash/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Word Mash | Daily Overlap Word Puzzle</title>
+  <meta name="description"
+    content="Play Word Mash: solve two clues and combine both answers into one overlap mash word. A fresh daily puzzle with streak tracking and share results." />
+  <meta name="keywords"
+    content="word mash, daily word game, overlap word puzzle, word blend game, wordle alternative, bludle" />
+  <link rel="stylesheet" href="/globalNav/globalNav.css">
+  <link rel="stylesheet" href="./style.css">
+  <script type="module" src="/globalNav/globalNav.js" defer></script>
+  <script type="text/javascript" src="/mixpanel.js"></script>
+  <script src="./script.js" defer></script>
+</head>
+
+<body>
+  <div id="navbar-container"></div>
+
+  <main class="page">
+    <section class="hero">
+      <p class="eyebrow">New Daily Game</p>
+      <h1>Word Mash</h1>
+      <p class="subtitle">Answer two clues. Then mash the words together so the end of answer one overlaps with the
+        start of answer two.</p>
+      <div class="badge-row">
+        <span class="badge" id="puzzle-date">Daily puzzle</span>
+        <span class="badge" id="streak-badge">Streak: 0</span>
+      </div>
+    </section>
+
+    <section class="game-shell" aria-live="polite">
+      <div class="clues">
+        <article class="clue-card">
+          <p class="clue-label">Clue 1</p>
+          <p class="clue-text" id="clue-one"></p>
+        </article>
+        <article class="clue-card">
+          <p class="clue-label">Clue 2</p>
+          <p class="clue-text" id="clue-two"></p>
+        </article>
+      </div>
+
+      <form id="guess-form" class="guess-form" autocomplete="off">
+        <label for="guess-input">Your mash word</label>
+        <div class="input-wrap">
+          <input id="guess-input" name="guess" type="text" maxlength="24" placeholder="e.g. dog + gown → dogown"
+            required />
+          <button type="submit" id="submit-btn">Check</button>
+        </div>
+      </form>
+
+      <div class="feedback" id="feedback">You get 6 guesses per day. Good luck!</div>
+
+      <section>
+        <h2>Attempts</h2>
+        <ol id="attempts" class="attempts"></ol>
+      </section>
+
+      <section class="result" id="result" hidden>
+        <h2 id="result-title"></h2>
+        <p id="result-message"></p>
+        <div class="result-actions">
+          <button id="share-btn" type="button">Copy result</button>
+          <button id="next-day-btn" type="button" disabled>Next puzzle tomorrow</button>
+        </div>
+      </section>
+    </section>
+
+    <aside class="ad-slot top-ad" aria-label="Advertisement placeholder">
+      <p>Ad placement area</p>
+      <small>Reserved for Google Ads top banner (responsive)</small>
+    </aside>
+
+    <section class="rules">
+      <h2>How to play</h2>
+      <ul>
+        <li>Solve both clues.</li>
+        <li>Merge the answers into one word where they overlap.</li>
+        <li>Example: <strong>star</strong> + <strong>artist</strong> = <strong>startist</strong>.</li>
+        <li>One puzzle per day. Your progress is saved in your browser.</li>
+      </ul>
+    </section>
+
+    <aside class="ad-slot bottom-ad" aria-label="Advertisement placeholder">
+      <p>Ad placement area</p>
+      <small>Reserved for Google Ads in-content rectangle</small>
+    </aside>
+  </main>
+</body>
+
+</html>

--- a/wordmash/script.js
+++ b/wordmash/script.js
@@ -1,6 +1,7 @@
 const MAX_ATTEMPTS = 6;
 const DAY_MS = 24 * 60 * 60 * 1000;
 const EPOCH_UTC = Date.UTC(2024, 0, 1);
+const HOWTO_DISMISSED_KEY = "wordmash-howto-dismissed";
 
 const PUZZLES = [
   {
@@ -147,14 +148,41 @@ function updateStreak(dayKey, solved) {
 function createShareText(dayKey, attempts, solved) {
   const rows = attempts.map(attempt => (attempt.correct ? "🟩" : "⬜")).join("");
   const score = solved ? attempts.length : "X";
-  return `Word Mash ${dayKey} ${score}/${MAX_ATTEMPTS}\n${rows}\nhttps://www.bludle.com/wordmash/`;
+  return `Word Mash ${dayKey} ${score}/${MAX_ATTEMPTS}\n${rows}\nNo spoilers. Can you beat me?\nhttps://www.bludle.com/wordmash/`;
+}
+
+function initialiseHowToModal() {
+  const overlay = document.getElementById("howto-overlay");
+  const dismissBtn = document.getElementById("dismiss-howto");
+  const openBtn = document.getElementById("open-howto");
+
+  const openModal = () => {
+    overlay.hidden = false;
+  };
+
+  const closeModal = () => {
+    overlay.hidden = true;
+    localStorage.setItem(HOWTO_DISMISSED_KEY, "true");
+  };
+
+  if (localStorage.getItem(HOWTO_DISMISSED_KEY) !== "true") {
+    openModal();
+  }
+
+  dismissBtn.addEventListener("click", closeModal);
+  openBtn.addEventListener("click", openModal);
+
+  overlay.addEventListener("click", event => {
+    if (event.target === overlay) {
+      closeModal();
+    }
+  });
 }
 
 function initialise() {
   const dayKey = todayUtcKey();
   const puzzle = PUZZLES[puzzleIndexForToday()];
   const expected = mashWord(puzzle.answer1, puzzle.answer2);
-
   const state = loadState(dayKey);
 
   const clueOne = document.getElementById("clue-one");
@@ -198,12 +226,12 @@ function initialise() {
       const streak = updateStreak(dayKey, true);
       streakBadge.textContent = `Streak: ${streak}`;
       resultTitle.textContent = "You nailed it!";
-      resultMessage.textContent = `Today's mash was ${expected.toUpperCase()} (${puzzle.answer1.toUpperCase()} + ${puzzle.answer2.toUpperCase()}).`;
+      resultMessage.textContent = "Nice work. Share your result without spoilers and challenge a friend.";
       feedback.textContent = "Great solve. Come back tomorrow for a fresh mash.";
     } else {
       streakBadge.textContent = `Streak: ${getStreak()}`;
       resultTitle.textContent = "Out of guesses";
-      resultMessage.textContent = `Today's mash was ${expected.toUpperCase()} (${puzzle.answer1.toUpperCase()} + ${puzzle.answer2.toUpperCase()}).`;
+      resultMessage.textContent = "No worries. Share your run and challenge a friend to beat it.";
       feedback.textContent = "Good attempt. A new puzzle unlocks tomorrow.";
     }
   }
@@ -256,16 +284,27 @@ function initialise() {
 
   shareBtn.addEventListener("click", async () => {
     const text = createShareText(dayKey, state.attempts, state.solved);
+
     try {
+      if (navigator.share) {
+        await navigator.share({
+          title: "Word Mash",
+          text
+        });
+        feedback.textContent = "Shared successfully.";
+        return;
+      }
+
       await navigator.clipboard.writeText(text);
-      feedback.textContent = "Result copied to clipboard.";
+      feedback.textContent = "Share text copied to clipboard.";
     } catch {
-      feedback.textContent = "Could not copy automatically. Share this manually:";
+      feedback.textContent = "Could not auto-share. Copy this result manually:";
       prompt("Copy your result", text);
     }
   });
 
   submitBtn.disabled = state.solved || state.attempts.length >= MAX_ATTEMPTS;
+  initialiseHowToModal();
 }
 
 window.addEventListener("DOMContentLoaded", initialise);

--- a/wordmash/script.js
+++ b/wordmash/script.js
@@ -157,11 +157,13 @@ function initialiseHowToModal() {
   const openBtn = document.getElementById("open-howto");
 
   const openModal = () => {
-    overlay.hidden = false;
+    overlay.classList.add("is-open");
+    overlay.setAttribute("aria-hidden", "false");
   };
 
   const closeModal = () => {
-    overlay.hidden = true;
+    overlay.classList.remove("is-open");
+    overlay.setAttribute("aria-hidden", "true");
     localStorage.setItem(HOWTO_DISMISSED_KEY, "true");
   };
 

--- a/wordmash/script.js
+++ b/wordmash/script.js
@@ -1,0 +1,271 @@
+const MAX_ATTEMPTS = 6;
+const DAY_MS = 24 * 60 * 60 * 1000;
+const EPOCH_UTC = Date.UTC(2024, 0, 1);
+
+const PUZZLES = [
+  {
+    clue1: "A glowing object in the night sky",
+    answer1: "star",
+    clue2: "Someone who creates paintings or music",
+    answer2: "artist"
+  },
+  {
+    clue1: "Earth's natural satellite",
+    answer1: "moon",
+    clue2: "The beginning of something",
+    answer2: "onset"
+  },
+  {
+    clue1: "Material used to write on",
+    answer1: "paper",
+    clue2: "A human being",
+    answer2: "person"
+  },
+  {
+    clue1: "A mythical fire-breathing creature",
+    answer1: "dragon",
+    clue2: "Still happening",
+    answer2: "ongoing"
+  },
+  {
+    clue1: "A shiny precious metal",
+    answer1: "silver",
+    clue2: "A jury's decision",
+    answer2: "verdict"
+  },
+  {
+    clue1: "The coldest season",
+    answer1: "winter",
+    clue2: "A station where trains arrive",
+    answer2: "terminal"
+  },
+  {
+    clue1: "The blooming part of a plant",
+    answer1: "flower",
+    clue2: "Rubber used to remove pencil marks",
+    answer2: "eraser"
+  },
+  {
+    clue1: "Loud sound during a storm",
+    answer1: "thunder",
+    clue2: "A plant used in cooking or medicine",
+    answer2: "herb"
+  }
+];
+
+function sanitize(input) {
+  return input.toLowerCase().replace(/[^a-z]/g, "");
+}
+
+function overlapLength(first, second) {
+  const max = Math.min(first.length, second.length);
+  for (let size = max; size > 0; size--) {
+    if (first.slice(-size) === second.slice(0, size)) {
+      return size;
+    }
+  }
+  return 0;
+}
+
+function mashWord(first, second) {
+  const overlap = overlapLength(first, second);
+  return first + second.slice(overlap);
+}
+
+function todayUtcKey() {
+  const now = new Date();
+  const yyyy = now.getUTCFullYear();
+  const mm = String(now.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(now.getUTCDate()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+function puzzleIndexForToday() {
+  const todayStart = new Date();
+  const dayNumber = Math.floor(Date.UTC(todayStart.getUTCFullYear(), todayStart.getUTCMonth(), todayStart.getUTCDate()) - EPOCH_UTC) / DAY_MS;
+  return ((dayNumber % PUZZLES.length) + PUZZLES.length) % PUZZLES.length;
+}
+
+function getStateKey(dayKey) {
+  return `wordmash-state-${dayKey}`;
+}
+
+function loadState(dayKey) {
+  const raw = localStorage.getItem(getStateKey(dayKey));
+  if (!raw) {
+    return { attempts: [], solved: false };
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    return {
+      attempts: Array.isArray(parsed.attempts) ? parsed.attempts : [],
+      solved: Boolean(parsed.solved)
+    };
+  } catch {
+    return { attempts: [], solved: false };
+  }
+}
+
+function saveState(dayKey, state) {
+  localStorage.setItem(getStateKey(dayKey), JSON.stringify(state));
+}
+
+function getStreak() {
+  return Number(localStorage.getItem("wordmash-streak") || 0);
+}
+
+function setStreak(value) {
+  localStorage.setItem("wordmash-streak", String(value));
+}
+
+function updateStreak(dayKey, solved) {
+  if (!solved) {
+    return getStreak();
+  }
+
+  const previousWin = localStorage.getItem("wordmash-last-win");
+  if (previousWin === dayKey) {
+    return getStreak();
+  }
+
+  const prevDate = previousWin ? Date.parse(`${previousWin}T00:00:00Z`) : null;
+  const currDate = Date.parse(`${dayKey}T00:00:00Z`);
+
+  let streak = getStreak();
+  if (prevDate && currDate - prevDate === DAY_MS) {
+    streak += 1;
+  } else {
+    streak = 1;
+  }
+
+  setStreak(streak);
+  localStorage.setItem("wordmash-last-win", dayKey);
+  return streak;
+}
+
+function createShareText(dayKey, attempts, solved) {
+  const rows = attempts.map(attempt => (attempt.correct ? "🟩" : "⬜")).join("");
+  const score = solved ? attempts.length : "X";
+  return `Word Mash ${dayKey} ${score}/${MAX_ATTEMPTS}\n${rows}\nhttps://www.bludle.com/wordmash/`;
+}
+
+function initialise() {
+  const dayKey = todayUtcKey();
+  const puzzle = PUZZLES[puzzleIndexForToday()];
+  const expected = mashWord(puzzle.answer1, puzzle.answer2);
+
+  const state = loadState(dayKey);
+
+  const clueOne = document.getElementById("clue-one");
+  const clueTwo = document.getElementById("clue-two");
+  const puzzleDate = document.getElementById("puzzle-date");
+  const streakBadge = document.getElementById("streak-badge");
+  const feedback = document.getElementById("feedback");
+  const form = document.getElementById("guess-form");
+  const guessInput = document.getElementById("guess-input");
+  const submitBtn = document.getElementById("submit-btn");
+  const attemptsEl = document.getElementById("attempts");
+  const resultSection = document.getElementById("result");
+  const resultTitle = document.getElementById("result-title");
+  const resultMessage = document.getElementById("result-message");
+  const shareBtn = document.getElementById("share-btn");
+
+  clueOne.textContent = puzzle.clue1;
+  clueTwo.textContent = puzzle.clue2;
+  puzzleDate.textContent = `Puzzle ${dayKey}`;
+
+  function renderAttempts() {
+    attemptsEl.innerHTML = "";
+    state.attempts.forEach((attempt, index) => {
+      const li = document.createElement("li");
+      li.className = attempt.correct ? "good" : "bad";
+      li.innerHTML = `<span>${index + 1}. ${attempt.value}</span><span>${attempt.correct ? "Correct" : "Try again"}</span>`;
+      attemptsEl.appendChild(li);
+    });
+  }
+
+  function setLockedResult() {
+    const lost = !state.solved && state.attempts.length >= MAX_ATTEMPTS;
+    if (!state.solved && !lost) {
+      return;
+    }
+
+    form.hidden = true;
+    resultSection.hidden = false;
+
+    if (state.solved) {
+      const streak = updateStreak(dayKey, true);
+      streakBadge.textContent = `Streak: ${streak}`;
+      resultTitle.textContent = "You nailed it!";
+      resultMessage.textContent = `Today's mash was ${expected.toUpperCase()} (${puzzle.answer1.toUpperCase()} + ${puzzle.answer2.toUpperCase()}).`;
+      feedback.textContent = "Great solve. Come back tomorrow for a fresh mash.";
+    } else {
+      streakBadge.textContent = `Streak: ${getStreak()}`;
+      resultTitle.textContent = "Out of guesses";
+      resultMessage.textContent = `Today's mash was ${expected.toUpperCase()} (${puzzle.answer1.toUpperCase()} + ${puzzle.answer2.toUpperCase()}).`;
+      feedback.textContent = "Good attempt. A new puzzle unlocks tomorrow.";
+    }
+  }
+
+  renderAttempts();
+  streakBadge.textContent = `Streak: ${getStreak()}`;
+  setLockedResult();
+
+  form.addEventListener("submit", event => {
+    event.preventDefault();
+
+    const value = sanitize(guessInput.value);
+    if (!value) {
+      feedback.textContent = "Type a word mash first.";
+      return;
+    }
+
+    if (state.solved || state.attempts.length >= MAX_ATTEMPTS) {
+      feedback.textContent = "Today's puzzle is complete. Come back tomorrow.";
+      return;
+    }
+
+    const correct = value === expected;
+    state.attempts.push({ value, correct });
+    if (correct) {
+      state.solved = true;
+    }
+
+    saveState(dayKey, state);
+    renderAttempts();
+
+    if (correct) {
+      feedback.textContent = "Perfect overlap!";
+      setLockedResult();
+      return;
+    }
+
+    const remaining = MAX_ATTEMPTS - state.attempts.length;
+    feedback.textContent = remaining > 0
+      ? `Not quite. ${remaining} ${remaining === 1 ? "guess" : "guesses"} left.`
+      : "No guesses left.";
+
+    if (state.attempts.length >= MAX_ATTEMPTS) {
+      setLockedResult();
+    }
+
+    guessInput.value = "";
+    guessInput.focus();
+  });
+
+  shareBtn.addEventListener("click", async () => {
+    const text = createShareText(dayKey, state.attempts, state.solved);
+    try {
+      await navigator.clipboard.writeText(text);
+      feedback.textContent = "Result copied to clipboard.";
+    } catch {
+      feedback.textContent = "Could not copy automatically. Share this manually:";
+      prompt("Copy your result", text);
+    }
+  });
+
+  submitBtn.disabled = state.solved || state.attempts.length >= MAX_ATTEMPTS;
+}
+
+window.addEventListener("DOMContentLoaded", initialise);

--- a/wordmash/style.css
+++ b/wordmash/style.css
@@ -33,6 +33,10 @@ body {
 
 .hero,
 .game-shell,
+
+.modal-overlay[hidden] {
+  display: none !important;
+}
 .modal {
   border: 1px solid var(--border);
   background: var(--card);
@@ -43,6 +47,10 @@ body {
 
 .hero,
 .game-shell,
+
+.modal-overlay[hidden] {
+  display: none !important;
+}
 .modal {
   padding: clamp(16px, 2.5vw, 24px);
 }
@@ -212,6 +220,10 @@ h2 {
   padding: 16px;
 }
 
+
+.modal-overlay[hidden] {
+  display: none !important;
+}
 .modal {
   width: min(560px, 96vw);
 }

--- a/wordmash/style.css
+++ b/wordmash/style.css
@@ -5,10 +5,7 @@
   --border: rgba(174, 198, 255, 0.28);
   --text: #eff3ff;
   --muted: #b9c3e5;
-  --accent: #7c8dff;
   --accent-2: #42e7f5;
-  --success: #40d39a;
-  --danger: #ff7684;
   --shadow: 0 24px 44px rgba(0, 0, 0, 0.35);
 }
 
@@ -36,8 +33,7 @@ body {
 
 .hero,
 .game-shell,
-.rules,
-.ad-slot {
+.modal {
   border: 1px solid var(--border);
   background: var(--card);
   border-radius: 18px;
@@ -46,8 +42,8 @@ body {
 }
 
 .hero,
-.rules,
-.ad-slot {
+.game-shell,
+.modal {
   padding: clamp(16px, 2.5vw, 24px);
 }
 
@@ -85,6 +81,10 @@ body {
   font-size: 0.85rem;
   color: #dbe5ff;
   background: rgba(124, 141, 255, 0.16);
+}
+
+.button-badge {
+  cursor: pointer;
 }
 
 .game-shell {
@@ -202,34 +202,28 @@ h2 {
   padding-top: 12px;
 }
 
-.result-actions {
-  display: flex;
-  gap: 10px;
-  flex-wrap: wrap;
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(2, 6, 23, 0.72);
+  display: grid;
+  place-items: center;
+  z-index: 90;
+  padding: 16px;
 }
 
-.result-actions button[disabled] {
-  opacity: 0.45;
-  cursor: not-allowed;
+.modal {
+  width: min(560px, 96vw);
 }
 
-.rules ul {
-  margin: 10px 0 0;
+.modal h2 {
+  margin-top: 0;
+}
+
+.modal ul {
+  margin: 0 0 16px;
   padding-left: 20px;
   color: var(--muted);
-}
-
-.ad-slot {
-  text-align: center;
-  min-height: 102px;
-  display: grid;
-  place-content: center;
-  color: var(--muted);
-  background: repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.04) 0, rgba(255, 255, 255, 0.04) 12px, rgba(255, 255, 255, 0.02) 12px, rgba(255, 255, 255, 0.02) 24px);
-}
-
-.ad-slot p {
-  margin: 0;
 }
 
 @media (max-width: 720px) {

--- a/wordmash/style.css
+++ b/wordmash/style.css
@@ -1,0 +1,247 @@
+:root {
+  --bg-1: #090b1a;
+  --bg-2: #141833;
+  --card: rgba(19, 24, 49, 0.84);
+  --border: rgba(174, 198, 255, 0.28);
+  --text: #eff3ff;
+  --muted: #b9c3e5;
+  --accent: #7c8dff;
+  --accent-2: #42e7f5;
+  --success: #40d39a;
+  --danger: #ff7684;
+  --shadow: 0 24px 44px rgba(0, 0, 0, 0.35);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  color: var(--text);
+  font-family: "Inter", "Segoe UI", Roboto, sans-serif;
+  background:
+    radial-gradient(circle at 15% 5%, rgba(124, 141, 255, 0.24), transparent 38%),
+    radial-gradient(circle at 85% 15%, rgba(66, 231, 245, 0.2), transparent 35%),
+    linear-gradient(160deg, var(--bg-1), var(--bg-2));
+}
+
+.page {
+  width: min(960px, 92vw);
+  margin: 84px auto 36px;
+  display: grid;
+  gap: 18px;
+}
+
+.hero,
+.game-shell,
+.rules,
+.ad-slot {
+  border: 1px solid var(--border);
+  background: var(--card);
+  border-radius: 18px;
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(8px);
+}
+
+.hero,
+.rules,
+.ad-slot {
+  padding: clamp(16px, 2.5vw, 24px);
+}
+
+.hero h1 {
+  margin: 8px 0;
+  font-size: clamp(2rem, 5vw, 3rem);
+  letter-spacing: 0.02em;
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--accent-2);
+  margin: 0;
+  font-size: 0.78rem;
+}
+
+.subtitle {
+  margin: 0;
+  max-width: 62ch;
+  color: var(--muted);
+}
+
+.badge-row {
+  margin-top: 14px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.badge {
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 0.85rem;
+  color: #dbe5ff;
+  background: rgba(124, 141, 255, 0.16);
+}
+
+.game-shell {
+  padding: clamp(14px, 3vw, 22px);
+}
+
+.clues {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.clue-card {
+  margin: 0;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: rgba(8, 12, 26, 0.45);
+  padding: 14px;
+}
+
+.clue-label {
+  margin: 0 0 6px;
+  color: var(--accent-2);
+  font-size: 0.84rem;
+}
+
+.clue-text {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.guess-form {
+  margin-top: 16px;
+}
+
+.guess-form label {
+  font-size: 0.92rem;
+  color: var(--muted);
+}
+
+.input-wrap {
+  margin-top: 8px;
+  display: flex;
+  gap: 10px;
+}
+
+input,
+button {
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  font: inherit;
+}
+
+input {
+  flex: 1;
+  padding: 12px 14px;
+  color: var(--text);
+  background: rgba(14, 18, 37, 0.75);
+}
+
+input:focus {
+  outline: 2px solid var(--accent-2);
+  outline-offset: 1px;
+}
+
+button {
+  cursor: pointer;
+  color: #081423;
+  background: linear-gradient(135deg, #9cb2ff, #42e7f5);
+  font-weight: 700;
+  padding: 12px 18px;
+}
+
+.feedback {
+  margin: 14px 0;
+  min-height: 22px;
+  color: var(--muted);
+}
+
+h2 {
+  margin: 12px 0 8px;
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.attempts {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.attempts li {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  display: flex;
+  justify-content: space-between;
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.attempts li.good {
+  border-color: rgba(64, 211, 154, 0.7);
+  background: rgba(64, 211, 154, 0.15);
+}
+
+.attempts li.bad {
+  border-color: rgba(255, 118, 132, 0.5);
+}
+
+.result {
+  margin-top: 12px;
+  border-top: 1px solid var(--border);
+  padding-top: 12px;
+}
+
+.result-actions {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.result-actions button[disabled] {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.rules ul {
+  margin: 10px 0 0;
+  padding-left: 20px;
+  color: var(--muted);
+}
+
+.ad-slot {
+  text-align: center;
+  min-height: 102px;
+  display: grid;
+  place-content: center;
+  color: var(--muted);
+  background: repeating-linear-gradient(45deg, rgba(255, 255, 255, 0.04) 0, rgba(255, 255, 255, 0.04) 12px, rgba(255, 255, 255, 0.02) 12px, rgba(255, 255, 255, 0.02) 24px);
+}
+
+.ad-slot p {
+  margin: 0;
+}
+
+@media (max-width: 720px) {
+  .clues {
+    grid-template-columns: 1fr;
+  }
+
+  .input-wrap {
+    flex-direction: column;
+  }
+
+  button {
+    width: 100%;
+  }
+}

--- a/wordmash/style.css
+++ b/wordmash/style.css
@@ -33,10 +33,6 @@ body {
 
 .hero,
 .game-shell,
-
-.modal-overlay[hidden] {
-  display: none !important;
-}
 .modal {
   border: 1px solid var(--border);
   background: var(--card);
@@ -47,10 +43,6 @@ body {
 
 .hero,
 .game-shell,
-
-.modal-overlay[hidden] {
-  display: none !important;
-}
 .modal {
   padding: clamp(16px, 2.5vw, 24px);
 }
@@ -214,16 +206,16 @@ h2 {
   position: fixed;
   inset: 0;
   background: rgba(2, 6, 23, 0.72);
-  display: grid;
+  display: none;
   place-items: center;
   z-index: 90;
   padding: 16px;
 }
 
-
-.modal-overlay[hidden] {
-  display: none !important;
+.modal-overlay.is-open {
+  display: grid;
 }
+
 .modal {
   width: min(560px, 96vw);
 }


### PR DESCRIPTION
### Motivation
- Provide a new front-end-only daily word puzzle that asks players two clue questions and requires an overlapping mash of both answers, presented with a polished UI and ad placeholders for future Google Ads placement.
- Integrate the new game into the existing site index, navigation and site metadata so it is discoverable and tracked like the other games.

### Description
- Added a new game under `wordmash/` with `index.html`, `style.css` and `script.js` implementing the two-clue overlap gameplay, polished visual design, responsive layout and explicit ad-slot placeholders.
- Implemented front-end daily rotation using a UTC-based day index, a small in-file `PUZZLES` list, mash generation via overlap detection, per-day persistence in `localStorage`, 6-attempt limit, solved/loss handling and streak tracking.
- Integrated the game into the site by adding a gradient-only tile to the home page, updating `index.html` SEO/ItemList metadata, adding a navigation entry in `globalNav/navLinks.js` and wiring a click tracker in `home.js`.
- Updated LLM guidance files (`llms.txt`, `llms-full.txt`) to include the new game and added copy/share functionality that produces a simple share text for social sharing.

### Testing
- Linted/checked JavaScript with `node --check wordmash/script.js` and `node --check home.js`, both succeeded.
- Served the site using `python -m http.server` and verified the `/wordmash/` page responded (HTTP 200) with `curl -I`, which succeeded.
- Captured automated screenshots of the new game page and the home tile using Playwright, which completed successfully and produced artifacts.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6c91d5a0c833189af169f1bf14c8a)