### PR TITLE
Add Google AdSense script to site HTML pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
   <meta charset="UTF-8">
   <title>404 Not Found</title>
   <style>

--- a/alternate/index.html
+++ b/alternate/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Alternate</title>

--- a/benefits/index.html
+++ b/benefits/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">

--- a/blogs/1.html
+++ b/blogs/1.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The Wonderful World of Word Games</title>

--- a/blogs/2.html
+++ b/blogs/2.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The Rise of Handheld Electronic Word Games</title>

--- a/blogs/3.html
+++ b/blogs/3.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>

--- a/blogs/4.html
+++ b/blogs/4.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Word Games and Their Impact on Speech and Language Development</title>

--- a/blogs/5.html
+++ b/blogs/5.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The Role of SENCO in Schools: Supporting Students with Dyslexia</title>

--- a/blogs/6.html
+++ b/blogs/6.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Quick Tips for Improving Your Word Game Skills</title>

--- a/blogs/7.html
+++ b/blogs/7.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Top 10 Word Games for Color Lovers</title>

--- a/blogs/8.html
+++ b/blogs/8.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>The Science of Why We Love Word Puzzles</title>

--- a/blogs/about.html
+++ b/blogs/about.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">

--- a/blogs/disclaimer.html
+++ b/blogs/disclaimer.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <title>Disclaimer - bludle.com</title>
     <script type="text/javascript" src="/mixpanel.js"></script>

--- a/bludle/index.html
+++ b/bludle/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <title>Bludle - Secret words encoded in shades of blue</title>
     <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
     <meta http-equiv="Pragma" content="no-cache" />

--- a/connex/index.html
+++ b/connex/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Connex</title>

--- a/game/nerdle.html
+++ b/game/nerdle.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <link rel='stylesheet' type='text/css' href='nerdle.css'>
     <script src="nerdle.js"></script>
     <link rel="preconnect" href="https://fonts.googleapis.com">

--- a/guesshue/index.html
+++ b/guesshue/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Guess Hue - find the odd one out!</title>

--- a/heardle/index.html
+++ b/heardle/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <title>Heardle</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/hunt/index.html
+++ b/hunt/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
   <meta charset="UTF-8">
   <meta name="description"
     content="Play XY Marks the Spot, a unique treasure hunt game with mathematical hints. Choose from easy, medium, and hard difficulty levels and find the treasure!">

--- a/imageedit/index.html
+++ b/imageedit/index.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <script src="imageedit.js"></script>
     <link rel="stylesheet" href="style.css">
     <title>animation</title>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Bludle | Daily Puzzle, Word, Colour and Reaction Games</title>

--- a/privacy.html
+++ b/privacy.html
@@ -2,6 +2,7 @@
 <html>
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
         <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
         <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">

--- a/push/index.html
+++ b/push/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <title>Reaction Time Game</title>
     <style>
         body, html {

--- a/reaction/index.html
+++ b/reaction/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Reaction Game</title>

--- a/seequence/index.html
+++ b/seequence/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Seequence</title>

--- a/shapecut/index.html
+++ b/shapecut/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <title>Shape Cutting Game</title>
     <style>
         #gameArea {

--- a/shiftyfades/index.html
+++ b/shiftyfades/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Shifty Fades</title>

--- a/tintuition/index.html
+++ b/tintuition/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Color Matching Game</title>

--- a/trak/index.html
+++ b/trak/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
   <title>Trak</title>

--- a/wordmash/index.html
+++ b/wordmash/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 
 <head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Word Mash | Daily Overlap Word Puzzle</title>


### PR DESCRIPTION
### Motivation
- Enable site monetization by loading the Google AdSense library on public pages using the publisher client id `ca-pub-5140172230633441`.
- Ensure the ad script is available consistently across the various static pages and mini-app entry points so ads can be initialized where needed.

### Description
- Injected the AdSense loader script tag ` <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>` into the top of the `<head>` for many HTML files (including `index.html`, `404.html`, blog pages under `blogs/`, and numerous game pages such as `bludle/`, `nerdle/`, `reaction/`, `guesshue/`, etc.).
- Preserved existing page content, metadata, and analytics snippets (e.g. Mixpanel and gtag) and did not alter page logic or other scripts.
- Applied the same insertion pattern across all modified files to keep head structure consistent site-wide.

### Testing
- No automated tests were executed for this change.
- Local/manual spot checks were used to confirm the AdSense script tag is present in the modified HTML files (no runtime ad behavior tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c26f0d24808331b1873157b9bdf8e7)