### PR TITLE
Replace blocking alerts with inline status messages in Werdle

### DIFF
--- a/game/nerdle.css
+++ b/game/nerdle.css
@@ -30,6 +30,20 @@ html {
     white-space: normal;
 }
 
+.statusAlert {
+    min-height: 20px;
+    margin: 6px auto 0;
+    color: #ffd7d7;
+    font-size: 0.9rem;
+    font-weight: bold;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+}
+
+.statusAlert.visible {
+    opacity: 1;
+}
+
 .letter {
     border-radius: 2px;
     margin-right: 2px;

--- a/game/nerdle.html
+++ b/game/nerdle.html
@@ -33,6 +33,7 @@
         <input type="text" onkeypress="enterSubmit(event)" onsubmit="gameAttempt()" id="userInput" placeholder="guess"
             style="margin-top: 10px; margin-bottom: 10px; height: 16px;"></input>
         <br>
+        <div id="statusAlert" class="statusAlert" aria-live="polite"></div>
 
         <div id="gameText" class="gameText"></div>
         <div id="bottomPortion" style="position: fixed;

--- a/game/nerdle.js
+++ b/game/nerdle.js
@@ -13,6 +13,15 @@ secret = (wordlist[Math.floor(Math.random() * wordlist.length)].toLowerCase());
 guess = "";
 guessNumber = 0;
 var def;
+var alertTimeout;
+
+function showStatusAlert(message) {
+    clearTimeout(alertTimeout);
+    $('#statusAlert').text(message).addClass('visible');
+    alertTimeout = setTimeout(function () {
+        $('#statusAlert').removeClass('visible').text('');
+    }, 1800);
+}
 
 function reset() {
     secret = (wordlist[Math.floor(Math.random() * wordlist.length)].toLowerCase())
@@ -124,7 +133,7 @@ function gameAttempt() {
             })
 
         } else {
-            alert("Invalid guess length. Try again.")
+            showStatusAlert("Invalid guess length. Try again.")
         }
         $('#gameText').append('</br>')
         $('#gameText').append('</div>')
@@ -154,7 +163,7 @@ function addKey(e) {
         $('#gameText').innerHTML = ""
     }
     if ($('#userInput').val().length == 5) {
-        alert("max length reached - 5 letter words only")
+        showStatusAlert("Max length reached — 5-letter words only.")
     }
     else {
         current = $('#userInput').val()


### PR DESCRIPTION
### Motivation
- Browser `alert()` dialogs were being suppressed or rendering inconsistently, causing important user feedback to not appear reliably in the Werdle game.
- Provide non-blocking, accessible feedback that stays in the page and works across browsers and devices.

### Description
- Added an inline status container `#statusAlert` under the input and set `aria-live="polite"` so assistive tech will announce messages. (`game/nerdle.html`).
- Implemented a reusable `showStatusAlert(message)` helper with auto-dismiss and safe reset via `clearTimeout`. (`game/nerdle.js`).
- Replaced blocking `alert()` calls with `showStatusAlert(...)` and updated the message text for clarity. (`game/nerdle.js`).
- Added styles for `.statusAlert` and `.statusAlert.visible` to animate visibility and ensure consistent presentation. (`game/nerdle.css`).

### Testing
- Ran `node --check game/nerdle.js` to validate the script syntax; it succeeded. 
- Verified occurrences of the new API via `rg -n "showStatusAlert|statusAlert|alert\("` to confirm `alert()` usage was replaced and the new element is referenced; results present as expected.
- Manual visual smoke testing was intended but a browser screenshot tool was not available in this environment, so UI verification should be performed in-browser as a follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c30c1f55cc833193ec4096083a1451)