### PR TITLE
Add Snoules embedded game page and wire it into site navigation

### DIFF
--- a/globalNav/navLinks.js
+++ b/globalNav/navLinks.js
@@ -14,5 +14,6 @@ export const navLinks = [
     { name: "tintuition", href: "/tintuition" },
     { name: "connex", href: "/connex" },
     { name: "seequence", href: "/seequence" },
-    { name: "word mash", href: "/wordmash" }
+    { name: "word mash", href: "/wordmash" },
+    { name: "snoules", href: "/snoules" }
 ];

--- a/home.js
+++ b/home.js
@@ -23,6 +23,7 @@ const tileHandlers = {
     connex: () => trackClick('connex'),
     heardle: () => trackClick('heardle'),
     wordmash: () => trackClick('wordmash'),
+    snoules: () => trackClick('snoules'),
 };
 
 window.addEventListener("DOMContentLoaded", () => {

--- a/index.html
+++ b/index.html
@@ -244,6 +244,13 @@
       </a>
     </div>
 
+    <div class="tile" id="snoules">
+      <a class="game" href="/snoules/" aria-label="Play Snoules" style="background-image: url('./images/icon.png')">
+        <div class="gameTitle">Snoules</div>
+        <div class="gameInfo">Play Snoules in an embedded game window</div>
+      </a>
+    </div>
+
     <div class="tile" id="heardle">
       <a class="game" href="/heardle/" aria-label="Play Heardle" style="background-image: url('./images/heardle.png')">
         <div class="gameTitle">Heardle</div>
@@ -282,6 +289,7 @@
       <li><a href="/codle/">Codle</a> - decode offset words with logic and pattern recognition.</li>
       <li><a href="/connex/">Connex</a> - find groups of related words by connection.</li>
       <li><a href="/wordmash/">Word Mash</a> - solve two clues and blend the answers with an overlap.</li>
+      <li><a href="/snoules/">Snoules</a> - play Snoules in an embedded game page.</li>
     </ul>
     <h3>Frequently asked questions</h3>
     <dl class="faq-list">
@@ -338,6 +346,7 @@
         <li><a href="/connex" target="_blank">connex</a></li>
         <li><a href="/seequence" target="_blank">seequence</a></li>
         <li><a href="/wordmash" target="_blank">word mash</a></li>
+        <li><a href="/snoules" target="_blank">snoules</a></li>
       </ul>
     </div>
   </footer>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -18,6 +18,7 @@
   <url><loc>https://www.bludle.com/seequence/</loc></url>
   <url><loc>https://www.bludle.com/shapecut/</loc></url>
   <url><loc>https://www.bludle.com/shiftyfades/</loc></url>
+  <url><loc>https://www.bludle.com/snoules/</loc></url>
   <url><loc>https://www.bludle.com/tintuition/</loc></url>
   <url><loc>https://www.bludle.com/trak/</loc></url>
   <url><loc>https://www.bludle.com/werdle/</loc></url>

--- a/snoules/index.html
+++ b/snoules/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Snoules</title>
+    <meta name="description" content="Play Snoules directly on Bludle." />
+    <link rel="stylesheet" href="/globalNav/globalNav.css" />
+    <script type="module" src="/globalNav/globalNav.js" defer></script>
+    <style>
+        :root {
+            --page-bg: #0f172a;
+            --card-bg: #111827;
+            --card-border: #1f2937;
+            --text-muted: #cbd5e1;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            min-height: 100vh;
+            background: radial-gradient(circle at 20% 20%, #1e293b 0%, #0b1220 60%, #060b16 100%);
+            color: #ffffff;
+            font-family: Arial, sans-serif;
+            display: flex;
+            flex-direction: column;
+        }
+
+        main {
+            width: min(1200px, 100%);
+            margin: calc(var(--global-nav-height, 64px) + 12px) auto 0;
+            padding: 12px;
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+        }
+
+        h1 {
+            margin: 0;
+            font-size: clamp(1.5rem, 3vw, 2rem);
+        }
+
+        p {
+            margin: 0;
+            color: var(--text-muted);
+        }
+
+        .frameWrap {
+            flex: 1;
+            min-height: 75vh;
+            border: 1px solid var(--card-border);
+            border-radius: 10px;
+            overflow: hidden;
+            background: var(--card-bg);
+            box-shadow: 0 8px 30px rgba(0, 0, 0, 0.35);
+        }
+
+        iframe {
+            width: 100%;
+            height: 100%;
+            min-height: 75vh;
+            border: 0;
+            background: #fff;
+        }
+    </style>
+</head>
+
+<body>
+    <div id="navbar-container"></div>
+    <main>
+        <h1>Snoules</h1>
+        <p>Snoules is embedded below.</p>
+        <div class="frameWrap">
+            <iframe src="https://snoules-f0f5a0f900cc.herokuapp.com/" title="Snoules game" loading="lazy" allowfullscreen></iframe>
+        </div>
+    </main>
+</body>
+
+</html>

--- a/snoules/index.html
+++ b/snoules/index.html
@@ -32,7 +32,7 @@
         }
 
         main {
-            width: min(1200px, 100%);
+            width: min(1320px, 100%);
             margin: calc(var(--global-nav-height, 64px) + 12px) auto 0;
             padding: 12px;
             flex: 1;
@@ -46,14 +46,9 @@
             font-size: clamp(1.5rem, 3vw, 2rem);
         }
 
-        p {
-            margin: 0;
-            color: var(--text-muted);
-        }
-
         .frameWrap {
             flex: 1;
-            min-height: 75vh;
+            min-height: 82.5vh;
             border: 1px solid var(--card-border);
             border-radius: 10px;
             overflow: hidden;
@@ -64,7 +59,7 @@
         iframe {
             width: 100%;
             height: 100%;
-            min-height: 75vh;
+            min-height: 82.5vh;
             border: 0;
             background: #fff;
         }
@@ -75,7 +70,6 @@
     <div id="navbar-container"></div>
     <main>
         <h1>Snoules</h1>
-        <p>Snoules is embedded below.</p>
         <div class="frameWrap">
             <iframe src="https://snoules-f0f5a0f900cc.herokuapp.com/" title="Snoules game" loading="lazy" allowfullscreen></iframe>
         </div>


### PR DESCRIPTION
### Motivation
- Provide direct access to the external Snoules game from the Bludle site by embedding it in a site page for a consistent user experience.
- Make the new game discoverable via the homepage, global navigation, footer and sitemap for SEO and usability.

### Description
- Added a new game page at `snoules/index.html` that includes the shared global nav and embeds `https://snoules-f0f5a0f900cc.herokuapp.com/` in a responsive iframe.
- Added `snoules` to the site dropdown/navigation by updating `globalNav/navLinks.js`.
- Added a homepage tile and descriptive text in `index.html` and included a homepage click tracker entry in `home.js` for the new tile.
- Added a `snoules` entry to `sitemap.xml` and inserted Snoules into the homepage SEO list and footer games list.

### Testing
- Inspected repository diffs and verified the intended changes and the new `snoules/index.html` file were created successfully; checks passed.
- Reviewed the updated `index.html`, `home.js`, `globalNav/navLinks.js`, and `sitemap.xml` to confirm the new links, tile, and tracking handler are present with no syntax errors detected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ce7d1448408331b94f130d5886b027)