### PR TITLE
Fix explainer (?) button overlap and normalize global navbar styling

### DIFF
--- a/globalNav/globalNav.css
+++ b/globalNav/globalNav.css
@@ -102,3 +102,15 @@
     outline: 2px solid #4fc3f7;
     outline-offset: 2px;
 }
+
+/* Keep navbar appearance stable regardless of page-level element styles. */
+#navbar-container .globalNav,
+#navbar-container .globalNav * {
+    box-sizing: border-box;
+    font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+}
+
+/* Keep the explainer help button below the fixed global nav. */
+button[aria-label="Open game explainer"] {
+    top: calc(var(--global-nav-height) + 12px) !important;
+}


### PR DESCRIPTION
### Motivation
- Prevent page-level CSS from changing the navbar's appearance and stop the game "?" explainer button from sitting on top of the fixed global navbar.

### Description
- Add scoped normalization rules in `globalNav/globalNav.css` under `#navbar-container` to enforce `box-sizing` and a consistent font stack for `.globalNav` and its descendants, and force `button[aria-label="Open game explainer"]` to `top: calc(var(--global-nav-height) + 12px) !important;` so the explainer button is placed below the navbar.

### Testing
- Ran `git diff --check` which completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d57287778c8331abb734e16616e332)