### PR TITLE
Overhaul home and navigation UI for stronger brand identity

### DIFF
--- a/globalNav/globalNav.css
+++ b/globalNav/globalNav.css
@@ -1,116 +1,122 @@
 :root {
-    --global-nav-height: 52px;
-    --global-ui-gap: 16px;
-    --global-toast-top: calc(var(--global-nav-height) + var(--global-ui-gap));
-    --global-nav-z: 1000;
-    --global-dropdown-z: 99999;
-    --global-overlay-z: 100100;
-    --global-toast-z: 100110;
+  --global-nav-height: 52px;
+  --global-ui-gap: 16px;
+  --global-toast-top: calc(var(--global-nav-height) + var(--global-ui-gap));
+  --global-nav-z: 1000;
+  --global-dropdown-z: 99999;
+  --global-overlay-z: 100100;
+  --global-toast-z: 100110;
 }
 
-/* Base Styles */
 .globalNav {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    background: linear-gradient(180deg, #263648, #1f2a38);
-    color: white;
-    padding: 0.5rem 1rem;
-    box-shadow: 0 4px 10px rgba(0, 0, 0, 0.28);
-    width: 100%;
-    position: fixed;
-    top: 0;
-    left: 0;
-    z-index: var(--global-nav-z);
-    box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  background: rgba(4, 10, 24, 0.82);
+  backdrop-filter: blur(10px);
+  border-bottom: 1px solid rgba(135, 170, 255, 0.3);
+  color: white;
+  padding: 0.55rem 1rem;
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.22);
+  width: 100%;
+  position: fixed;
+  top: 0;
+  left: 0;
+  z-index: var(--global-nav-z);
 }
 
 .brand {
-    display: flex;
-    align-items: center;
-    font-size: 1.5rem;
-    font-weight: bold;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.brand a {
-    color: white;
-    text-decoration: none;
-    margin-right: 10px;
+.brand-link {
+  color: white;
+  text-decoration: none;
+  font-family: 'Space Grotesk', system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  font-size: 1.25rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
 }
 
-.brand a:hover {
-    color: #4fc3f7;
+.brand-link:hover {
+  color: #7dd7ff;
 }
 
 .brand img {
-    height: 28px;
-    width: 28px;
-    border-radius: 5px;
+  height: 30px;
+  width: 30px;
+  border-radius: 8px;
 }
 
-/* Dropdown Menu Toggle */
 .menu-toggle {
-    background: #4fc3f7;
-    color: #fff;
-    padding: 0.5rem 1rem;
-    font-size: 1rem;
-    border: none;
-    border-radius: 8px;
-    cursor: pointer;
-    z-index: var(--global-dropdown-z);
+  background: linear-gradient(120deg, #4090ff, #7566ff);
+  color: #fff;
+  padding: 0.45rem 0.8rem;
+  font-size: 0.92rem;
+  font-weight: 700;
+  border: none;
+  border-radius: 10px;
+  cursor: pointer;
+  z-index: var(--global-dropdown-z);
 }
 
-/* Dropdown styles */
+.menu-toggle:hover {
+  filter: brightness(1.12);
+}
+
 .dropdown-menu {
-    display: none;
-    position: absolute;
-    top: 50px;
-    right: 1rem;
-    background: #1f2a38;
-    border: 1px solid #3f4a56;
-    border-radius: 8px;
-    list-style: none;
-    padding: 0.5rem 0;
-    min-width: 180px;
-    z-index: var(--global-dropdown-z);
+  display: none;
+  position: absolute;
+  top: calc(100% + 0.45rem);
+  right: 1rem;
+  background: rgba(8, 17, 39, 0.98);
+  border: 1px solid rgba(135, 170, 255, 0.35);
+  border-radius: 12px;
+  list-style: none;
+  padding: 0.4rem;
+  min-width: 220px;
+  max-height: 70vh;
+  overflow-y: auto;
+  box-shadow: 0 18px 44px rgba(0, 0, 0, 0.38);
+  z-index: var(--global-dropdown-z);
 }
 
 .dropdown-menu.active {
-    display: block;
-}
-
-.dropdown-menu li {
-    text-align: left;
+  display: block;
 }
 
 .dropdown-menu li a {
-    display: block;
-    padding: 0.5rem 1rem;
-    color: white;
-    text-decoration: none;
-    transition: background-color 0.3s, color 0.3s;
+  display: block;
+  padding: 0.52rem 0.68rem;
+  border-radius: 9px;
+  color: #dce8ff;
+  text-decoration: none;
+  font-size: 0.92rem;
+  transition: background-color 0.2s, color 0.2s;
 }
 
 .dropdown-menu li a:hover,
 .dropdown-menu li a.active {
-    background-color: #4fc3f7;
-    color: #1f2a38;
+  background-color: rgba(89, 200, 255, 0.22);
+  color: #fff;
 }
 
 .menu-toggle:focus-visible,
-.dropdown-menu li a:focus-visible {
-    outline: 2px solid #4fc3f7;
-    outline-offset: 2px;
+.dropdown-menu li a:focus-visible,
+.brand-link:focus-visible {
+  outline: 2px solid #7dd7ff;
+  outline-offset: 2px;
 }
 
-/* Keep navbar appearance stable regardless of page-level element styles. */
 #navbar-container .globalNav,
 #navbar-container .globalNav * {
-    box-sizing: border-box;
-    font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  box-sizing: border-box;
+  font-family: 'Manrope', system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
 }
 
-/* Keep the explainer help button below the fixed global nav. */
 button[aria-label="Open game explainer"] {
-    top: calc(var(--global-nav-height) + 12px) !important;
+  top: calc(var(--global-nav-height) + 12px) !important;
 }

--- a/globalNav/globalNav.js
+++ b/globalNav/globalNav.js
@@ -7,37 +7,50 @@ function sendEvent(eventName, params) {
 }
 
 function createNavbarHTML() {
-  const nav = document.createElement("nav");
-  nav.className = "globalNav";
+  const nav = document.createElement('nav');
+  nav.className = 'globalNav';
 
-  // Brand section
-  const brand = document.createElement("div");
-  brand.className = "brand";
-  brand.innerHTML = `
-    <a href="/" onclick="sendEvent('navSelection', { interaction_type: 'click', item_name: 'home' })">Bludle</a>
-    <img src="https://www.bludle.com/images/icon.png" style="margin-left:10px; height:28px; width:28px; border-radius:5px;" />
-  `;
+  const brand = document.createElement('div');
+  brand.className = 'brand';
+
+  const brandLink = document.createElement('a');
+  brandLink.className = 'brand-link';
+  brandLink.href = '/';
+  brandLink.textContent = 'Bludle';
+  brandLink.addEventListener('click', () => {
+    sendEvent('navSelection', { interaction_type: 'click', item_name: 'home' });
+  });
+
+  const brandLogo = document.createElement('img');
+  brandLogo.src = '/images/icon.png';
+  brandLogo.alt = 'Bludle logo';
+
+  brand.appendChild(brandLink);
+  brand.appendChild(brandLogo);
   nav.appendChild(brand);
 
-  // Dropdown button
-  const dropdownToggle = document.createElement("button");
-  dropdownToggle.className = "menu-toggle";
-  dropdownToggle.id = "dropdown-toggle";
-  dropdownToggle.innerHTML = `Menu &#x2630;`; // ☰
+  const dropdownToggle = document.createElement('button');
+  dropdownToggle.className = 'menu-toggle';
+  dropdownToggle.id = 'dropdown-toggle';
+  dropdownToggle.type = 'button';
+  dropdownToggle.setAttribute('aria-expanded', 'false');
+  dropdownToggle.setAttribute('aria-controls', 'dropdown-menu');
+  dropdownToggle.textContent = 'Menu ☰';
   nav.appendChild(dropdownToggle);
 
-  // Dropdown menu
-  const dropdownMenu = document.createElement("ul");
-  dropdownMenu.className = "dropdown-menu";
+  const dropdownMenu = document.createElement('ul');
+  dropdownMenu.className = 'dropdown-menu';
+  dropdownMenu.id = 'dropdown-menu';
 
-  navLinks.forEach(link => {
-    const li = document.createElement("li");
-    const a = document.createElement("a");
+  navLinks.forEach((link) => {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
     a.href = link.href;
     a.textContent = link.name;
-    a.addEventListener("click", () => {
+    a.addEventListener('click', () => {
       sendEvent('navSelection', { interaction_type: 'click', item_name: link.name });
-      dropdownMenu.classList.remove("active");
+      dropdownMenu.classList.remove('active');
+      dropdownToggle.setAttribute('aria-expanded', 'false');
     });
     li.appendChild(a);
     dropdownMenu.appendChild(li);
@@ -54,33 +67,36 @@ function syncNavMetrics(nav) {
 
   const root = document.documentElement;
   const navHeight = Math.ceil(nav.getBoundingClientRect().height);
-  root.style.setProperty("--global-nav-height", `${navHeight}px`);
-  root.style.setProperty("--global-toast-top", `calc(${navHeight}px + var(--global-ui-gap))`);
+  root.style.setProperty('--global-nav-height', `${navHeight}px`);
+  root.style.setProperty('--global-toast-top', `calc(${navHeight}px + var(--global-ui-gap))`);
 }
 
-document.addEventListener("DOMContentLoaded", () => {
-  const container = document.getElementById("navbar-container");
-  if (container) {
-    const nav = createNavbarHTML();
-    container.appendChild(nav);
-
-    const toggle = document.getElementById("dropdown-toggle");
-    const dropdown = document.querySelector(".dropdown-menu");
-
-    syncNavMetrics(nav);
-
-    toggle.addEventListener("click", () => {
-      dropdown.classList.toggle("active");
-      syncNavMetrics(nav);
-    });
-
-    // Optional: close dropdown when clicking outside
-    document.addEventListener("click", (e) => {
-      if (!toggle.contains(e.target) && !dropdown.contains(e.target)) {
-        dropdown.classList.remove("active");
-      }
-    });
-
-    window.addEventListener("resize", () => syncNavMetrics(nav));
+document.addEventListener('DOMContentLoaded', () => {
+  const container = document.getElementById('navbar-container');
+  if (!container) {
+    return;
   }
+
+  const nav = createNavbarHTML();
+  container.appendChild(nav);
+
+  const toggle = document.getElementById('dropdown-toggle');
+  const dropdown = document.getElementById('dropdown-menu');
+
+  syncNavMetrics(nav);
+
+  toggle.addEventListener('click', () => {
+    const isOpen = dropdown.classList.toggle('active');
+    toggle.setAttribute('aria-expanded', String(isOpen));
+    syncNavMetrics(nav);
+  });
+
+  document.addEventListener('click', (event) => {
+    if (!toggle.contains(event.target) && !dropdown.contains(event.target)) {
+      dropdown.classList.remove('active');
+      toggle.setAttribute('aria-expanded', 'false');
+    }
+  });
+
+  window.addEventListener('resize', () => syncNavMetrics(nav));
 });

--- a/home.css
+++ b/home.css
@@ -1,45 +1,98 @@
 :root {
-  --surface-dark: #1f2933;
-  --surface-darker: #101820;
-  --surface-mid: #2c3e50;
-  --text-primary: #f5f7fa;
-  --text-secondary: #d3dae3;
-  --accent-cyan: #4fc3f7;
-  --accent-blue: rgba(0, 146, 255, 0.85);
-  --accent-pink: rgba(255, 0, 184, 0.85);
-  --radius-md: 12px;
-  --radius-lg: 16px;
-  --shadow-soft: 0 8px 16px rgba(0, 0, 0, 0.3);
-  --shadow-strong: 0 12px 24px rgba(0, 0, 0, 0.4);
+  --bg: #081126;
+  --bg-soft: #111c35;
+  --panel: rgba(13, 24, 46, 0.78);
+  --text-primary: #f5f8ff;
+  --text-secondary: #adc0e5;
+  --brand: #59c8ff;
+  --brand-strong: #7a6dff;
+  --accent: #ff5db1;
+  --border: rgba(135, 170, 255, 0.28);
+  --radius-md: 14px;
+  --radius-lg: 22px;
+  --shadow-soft: 0 10px 24px rgba(0, 0, 0, 0.26);
+  --shadow-strong: 0 18px 42px rgba(0, 0, 0, 0.35);
+}
+
+* {
+  box-sizing: border-box;
 }
 
 body {
   margin: 0;
-  padding: 0;
-  margin-top: 60px;
-  background: linear-gradient(145deg, var(--surface-mid), #34495e 42%, #2b3a4d);
-  font-family: 'Roboto Condensed', sans-serif;
+  padding: calc(var(--global-nav-height) + 1.5rem) 0 0;
+  background:
+    radial-gradient(circle at 18% 10%, rgba(99, 198, 255, 0.22), transparent 34%),
+    radial-gradient(circle at 86% 0%, rgba(182, 101, 255, 0.22), transparent 28%),
+    linear-gradient(160deg, var(--bg), var(--bg-soft));
+  font-family: 'Manrope', system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
   color: var(--text-primary);
-  line-height: 1.4;
+  line-height: 1.45;
+}
+
+.home-hero {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1.2rem 2rem 1.4rem;
+}
+
+.hero-kicker {
+  margin: 0;
+  font-family: 'Space Grotesk', sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  font-size: 0.78rem;
+  color: var(--brand);
+}
+
+.home-hero h1 {
+  margin: 0.55rem 0 0.65rem;
+  max-width: 22ch;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: clamp(1.7rem, 4.1vw, 2.8rem);
+  line-height: 1.1;
+}
+
+.hero-subtitle {
+  margin: 0;
+  max-width: 64ch;
+  color: var(--text-secondary);
+}
+
+.hero-chips {
+  display: flex;
+  gap: 0.65rem;
+  margin-top: 1rem;
+  flex-wrap: wrap;
+}
+
+.hero-chips span {
+  background: rgba(89, 200, 255, 0.14);
+  border: 1px solid rgba(89, 200, 255, 0.35);
+  color: #d2ecff;
+  border-radius: 999px;
+  padding: 0.32rem 0.7rem;
+  font-size: 0.82rem;
+  font-weight: 600;
 }
 
 .content {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
-  gap: 2rem;
-  padding: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.35rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 1rem 2rem 2.2rem;
 }
 
 .tile {
   display: flex;
-  justify-content: center;
 }
 
 .game {
   cursor: pointer;
-  height: 300px;
+  min-height: 248px;
   width: 100%;
-  max-width: 400px;
   border-radius: var(--radius-lg);
   overflow: hidden;
   background-size: cover;
@@ -47,16 +100,59 @@ body {
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
-  text-align: center;
-  box-shadow: var(--shadow-soft);
-  transition: transform 0.3s ease, box-shadow 0.3s ease;
   text-decoration: none;
   color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: var(--shadow-soft);
+  position: relative;
+  isolation: isolate;
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+}
+
+.game::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: -1;
+  background: linear-gradient(to top, rgba(2, 8, 24, 0.95), rgba(5, 12, 32, 0.32) 50%, transparent 85%);
 }
 
 .game:focus-visible {
-  outline: 3px solid var(--accent-cyan);
-  outline-offset: 4px;
+  outline: 3px solid var(--brand);
+  outline-offset: 3px;
+}
+
+.game:hover {
+  transform: translateY(-6px);
+  box-shadow: var(--shadow-strong);
+  border-color: rgba(154, 202, 255, 0.65);
+}
+
+.gameTitle {
+  background: transparent;
+  color: #fff;
+  padding: 0 1rem 0.35rem;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.25rem;
+  font-weight: 700;
+  text-shadow: 0 3px 12px rgba(0, 0, 0, 0.55);
+}
+
+.gameInfo {
+  background: linear-gradient(95deg, rgba(122, 109, 255, 0.95), rgba(255, 93, 177, 0.95));
+  color: white;
+  min-height: 56px;
+  padding: 0.55rem 0.9rem 0.65rem;
+  display: flex;
+  align-items: center;
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.coffee-button {
+  height: 56px;
+  width: 200px;
+  margin: 0 auto 0.55rem;
 }
 
 .sr-only {
@@ -71,54 +167,39 @@ body {
   border: 0;
 }
 
-.game:hover {
-  transform: translateY(-5px);
-  box-shadow: var(--shadow-strong);
+.seo-content {
+  max-width: 1200px;
+  margin: 0 auto 2rem;
+  padding: 1.25rem 2rem 0;
+  color: var(--text-secondary);
 }
 
-.gameTitle {
-  background: var(--accent-blue);
-  color: white;
-  padding: 0.6rem;
-  font-size: 1.2rem;
-  font-weight: bold;
+.seo-content h2,
+.seo-content h3,
+.faq-list dt {
+  color: var(--text-primary);
 }
 
-.gameInfo {
-  background: var(--accent-pink);
-  color: white;
-  min-height: 50px;
-  padding: 0.4rem 0.75rem;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  font-size: 0.95rem;
-  font-weight: 500;
+.seo-content a {
+  color: #8fdcff;
 }
 
-.cookies {
-  position: fixed;
-  left: 0;
-  bottom: 0;
-  width: 100%;
-  background-color: #2c3e50;
-  color: white;
-  text-align: center;
-  padding: 5px;
-  font-size: 0.9rem;
+.faq-list dd {
+  margin-left: 0;
 }
 
 .footer {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
   gap: 2rem;
-  background: linear-gradient(180deg, var(--surface-dark), var(--surface-darker));
+  background: linear-gradient(180deg, rgba(10, 18, 37, 0.88), rgba(10, 18, 37, 1));
+  border-top: 1px solid var(--border);
   color: var(--text-secondary);
   padding: 2rem;
 }
 
 .footer-section h4 {
-  margin-bottom: 0.75rem;
+  margin: 0 0 0.75rem;
   color: var(--text-primary);
 }
 
@@ -132,66 +213,38 @@ body {
   margin-bottom: 0.5rem;
 }
 
-.footer-section ul li a,
-.footer-section>a {
+.footer-section a {
   text-decoration: none;
-  color: var(--accent-cyan);
-  border-radius: var(--radius-md);
-  transition: color 0.2s ease, background-color 0.2s ease;
+  color: #8fdcff;
 }
 
-.footer-section ul li a {
-  display: inline-block;
-  padding: 0.1rem 0.35rem;
+.footer-section a:hover {
+  color: #cdefff;
 }
 
-.footer-section ul li a:hover {
-  text-decoration: none;
-  background-color: rgba(79, 195, 247, 0.18);
-}
+@media (max-width: 700px) {
+  body {
+    padding-top: calc(var(--global-nav-height) + 1rem);
+  }
 
-.footer-section a:focus-visible {
-  outline: 2px solid var(--accent-cyan);
-  outline-offset: 2px;
-}
+  .home-hero,
+  .content,
+  .seo-content,
+  .footer {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
 
-@media (max-width: 600px) {
+  .content {
+    grid-template-columns: 1fr;
+    gap: 1rem;
+  }
+
   .game {
-    height: 240px;
+    min-height: 220px;
   }
 
   .gameInfo {
     font-size: 0.85rem;
   }
-
-  .cookies {
-    font-size: 0.8rem;
-  }
-}
-
-
-.seo-content {
-  max-width: 1100px;
-  margin: 0 auto 2rem;
-  padding: 0 2rem;
-  color: var(--text-secondary);
-}
-
-.seo-content h2,
-.seo-content h3 {
-  color: var(--text-primary);
-}
-
-.seo-content a {
-  color: var(--accent-cyan);
-}
-
-.faq-list dt {
-  margin-top: 1rem;
-  font-weight: 700;
-  color: var(--text-primary);
-}
-
-.faq-list dd {
-  margin-left: 0;
 }

--- a/home.js
+++ b/home.js
@@ -1,34 +1,41 @@
 function sendEvent(category, action, label) {
-    if ("ga" in window) {
-        const tracker = ga.getAll()[0];
-        if (tracker) {
-            tracker.send("event", category, action, label);
-        }
+  if ('ga' in window) {
+    const tracker = ga.getAll()[0];
+    if (tracker) {
+      tracker.send('event', category, action, label);
     }
+  }
 }
 
 const trackClick = (gameName) => {
-    sendEvent('homeSelection', 'Click', gameName);
+  sendEvent('homeSelection', 'Click', gameName);
 };
 
 const tileHandlers = {
-    nerdle: () => trackClick('nerdle'),
-    reaction: () => trackClick('reaction'),
-    colourMatch: () => trackClick('colourMatch'),
-    bludle: () => trackClick('bludle'),
-    codle: () => trackClick('codle'),
-    hunt: () => trackClick('hunt'),
-    guesshue: () => trackClick('guesshue'),
-    alternate: () => trackClick('alternate'),
-    connex: () => trackClick('connex'),
-    heardle: () => trackClick('heardle'),
-    wordmash: () => trackClick('wordmash'),
-    snoules: () => trackClick('snoules'),
+  bludle: () => trackClick('bludle'),
+  werdle: () => trackClick('werdle'),
+  reaction: () => trackClick('reaction'),
+  shiftyFades: () => trackClick('shiftyFades'),
+  colourMatch: () => trackClick('colourMatch'),
+  codle: () => trackClick('codle'),
+  alternate: () => trackClick('alternate'),
+  tintuition: () => trackClick('tintuition'),
+  hunt: () => trackClick('hunt'),
+  guesshue: () => trackClick('guesshue'),
+  trak: () => trackClick('trak'),
+  connex: () => trackClick('connex'),
+  wordmash: () => trackClick('wordmash'),
+  snoules: () => trackClick('snoules'),
+  heardle: () => trackClick('heardle'),
+  seequence: () => trackClick('seequence'),
+  coffee: () => trackClick('coffee'),
 };
 
-window.addEventListener("DOMContentLoaded", () => {
-    Object.entries(tileHandlers).forEach(([id, handler]) => {
-        const el = document.getElementById(id);
-        if (el) el.addEventListener("click", handler);
-    });
+window.addEventListener('DOMContentLoaded', () => {
+  Object.entries(tileHandlers).forEach(([id, handler]) => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.addEventListener('click', handler);
+    }
+  });
 });

--- a/index.html
+++ b/index.html
@@ -2,7 +2,6 @@
 <html lang="en">
 
 <head>
-    <style>@font-face{font-family:'Roboto Condensed';font-style:normal;font-weight:400;font-display:swap;src:url(https://fonts.gstatic.com/s/robotocondensed/v31/ieVo2ZhZI2eCN5jzbjEETS9weq8-_d6T_POl0fRJeyWyovBJ.ttf) format('truetype')}:root{--surface-dark:#1f2933;--surface-darker:#101820;--surface-mid:#2c3e50;--text-primary:#f5f7fa;--text-secondary:#d3dae3;--accent-cyan:#4fc3f7;--accent-blue:rgba(0, 146, 255, 0.85);--accent-pink:rgba(255, 0, 184, 0.85);--radius-md:12px;--radius-lg:16px;--shadow-soft:0 8px 16px rgba(0, 0, 0, 0.3);--shadow-strong:0 12px 24px rgba(0, 0, 0, 0.4)}body{margin:0;padding:0;margin-top:60px;background:linear-gradient(145deg,var(--surface-mid),#34495e 42%,#2b3a4d);font-family:'Roboto Condensed',sans-serif;color:var(--text-primary);line-height:1.4}.content{display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:2rem;padding:2rem}.tile{display:flex;justify-content:center}.game{height:300px;width:100%;max-width:400px;border-radius:var(--radius-lg);overflow:hidden;background-size:cover;background-position:center;display:flex;flex-direction:column;justify-content:flex-end;text-align:center;box-shadow:var(--shadow-soft);text-decoration:none;color:inherit}.sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}.gameTitle{background:var(--accent-blue);color:#fff;padding:.6rem;font-size:1.2rem;font-weight:700}.gameInfo{background:var(--accent-pink);color:#fff;min-height:50px;padding:.4rem .75rem;display:flex;justify-content:center;align-items:center;font-size:.95rem;font-weight:500}@media (max-width:600px){.game{height:240px}.gameInfo{font-size:.85rem}}:root{--global-nav-height:52px;--global-ui-gap:16px;--global-toast-top:calc(var(--global-nav-height) + var(--global-ui-gap));--global-nav-z:1000;--global-dropdown-z:99999;--global-overlay-z:100100;--global-toast-z:100110}</style>
     <script async="" src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-5140172230633441" crossorigin="anonymous"></script>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -22,7 +21,9 @@
   <meta name="twitter:title" content="Bludle | Daily Puzzle, Word, Colour and Reaction Games">
   <meta name="twitter:description" content="Play free daily puzzle and brain-training games including Bludle, Werdle, Reaction and more.">
   <meta name="twitter:image" content="https://www.bludle.com/images/background.jpg">
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Roboto+Condensed&amp;display=swap">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;700;800&family=Space+Grotesk:wght@500;700&display=swap">
   <link rel="stylesheet" href="home.css">
   <link rel="stylesheet" href="/globalNav/globalNav.css">
   <script type="module" src="/globalNav/globalNav.js" defer=""></script>
@@ -116,8 +117,20 @@
 <body>
   <div id="navbar-container"></div>
 
+  <header class="home-hero" aria-labelledby="home-title">
+    <p class="hero-kicker">Playful puzzles. Premium feel.</p>
+    <h1 id="home-title">A modern arcade for word, colour and logic games.</h1>
+    <p class="hero-subtitle">Discover daily challenges, unlimited practice modes, and fast games designed to be fun in under 5 minutes.</p>
+    <div class="hero-chips" aria-label="Game categories">
+      <span>Daily Word</span>
+      <span>Colour + Vision</span>
+      <span>Logic + Memory</span>
+      <span>Speed + Reaction</span>
+    </div>
+  </header>
+
   <main class="content" id="content">
-    <h1 class="sr-only">bludle Daily Puzzle Games</h1>
+    <h2 class="sr-only">bludle Daily Puzzle Games</h2>
     <div class="tile" id="bludle">
       <a class="game" href="/bludle/" aria-label="Play Bludle" style="background-image: url('./images/bludle.jpg')">
         <div class="gameTitle">Bludle</div>
@@ -241,7 +254,7 @@
     <div class="tile" id="coffee">
       <a class="game" href="https://www.buymeacoffee.com/stuart1510K" target="_blank">
         <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee"
-          style="height: 60px; width: 217px; margin: auto; transform: translateY(-85%);" />
+          class="coffee-button" />
         <div class="gameTitle">Buy me a coffee (beer) :)</div>
         <div class="gameInfo">Donate some beer tokens if you enjoy the games</div>
       </a>
@@ -283,17 +296,17 @@
       <p>These games may help maintain or improve brain function.</p>
     </div>
 
-    <div class=”footer-section”>
+    <div class="footer-section">
       <h4>Support &amp; Contact</h4>
-      <p>Use the “Buy me a coffee” link above to help maintain and grow the site. Thank you!</p>
-      <p>Questions or feedback? <a href=”/about/#contact-form”>Get in touch</a></p>
-      <p><a href=”https://www.facebook.com/profile.php?id=61552171184790” target=”_blank” rel=”noopener”>Follow us on Facebook</a></p>
+      <p>Use the "Buy me a coffee" link above to help maintain and grow the site. Thank you!</p>
+      <p>Questions or feedback? <a href="/about/#contact-form">Get in touch</a></p>
+      <p><a href="https://www.facebook.com/profile.php?id=61552171184790" target="_blank" rel="noopener">Follow us on Facebook</a></p>
     </div>
 
-    <div class=”footer-section”>
+    <div class="footer-section">
       <h4>Quick Links</h4>
       <ul>
-        <li><a href=”/about/” target=”_blank”>About</a></li>
+        <li><a href="/about/" target="_blank">About</a></li>
         <li><a href="/blogs/1" target="_blank">The Wonderful World of Word Games</a></li>
         <li><a href="/blogs/2" target="_blank">The Rise of Handheld Electronic Word Games</a></li>
         <li><a href="/blogs/3" target="_blank">The Rise of Indie Video Games</a></li>


### PR DESCRIPTION
### Motivation
- Refresh the site's first impression with a modern, cohesive brand identity that feels professional, playful and consistent across the home screen and navigation.  
- Improve readability, spacing, fonts and hover/focus states while removing brittle inline styles and malformed quote characters.  
- Make the global nav more accessible and the home tiles’ telemetry coverage consistent for reliable analytics.

### Description
- Reworked the homepage: removed the large inline head style, added a hero section and normalized semantic headings in `index.html`, swapped to `Manrope` + `Space Grotesk` fonts, and replaced the inline coffee image sizing with a `coffee-button` class.  
- Rebuilt layout and visual system in `home.css` with a new palette, updated CSS variables, improved card styling, gradients, spacing rhythm, hover and focus states, responsive tweaks and a dedicated hero/chips component.  
- Modernized navigation styling in `globalNav/globalNav.css` (glassmorphism-like background, refined brand lockup, updated button and dropdown appearance) and reimplemented interaction/accessibility in `globalNav/globalNav.js` (explicit `aria-expanded`, `aria-controls`, dropdown id, nav-height sync).  
- Expanded home-side analytics bindings and normalized event tracking in `home.js` so every visible tile (e.g. `werdle`, `seequence`, `coffee`, etc.) is tracked, and cleaned up malformed curly quotes and attributes in `index.html`.

### Testing
- Ran `git diff --check` to ensure no whitespace/merge issues and it succeeded.  
- Ran `rg -n '”|“' index.html home.css globalNav/globalNav.css globalNav/globalNav.js home.js || true` to verify smart/curly quotes were normalized and it returned clean results.  
- Verified file updates by inspecting `index.html`, `home.css`, `globalNav/globalNav.css`, `globalNav/globalNav.js`, and `home.js` in the working tree; no automated visual/browser tests were available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de9cbca8c48331a5710edbe411ce71)