### PR TITLE
Improve reaction game mobile layout and modal responsiveness

### DIFF
--- a/reaction/index.html
+++ b/reaction/index.html
@@ -23,12 +23,16 @@
       font-family: Arial, sans-serif;
       text-align: center;
       padding: 0;
-      padding-top: 50px;
-      height: calc(100vh - 50px);
       margin: 0;
+      min-height: 100svh;
       animation: hue-rotate-animation 10s infinite linear;
       background: black;
       color: white;
+      display: flex;
+      justify-content: center;
+      align-items: flex-start;
+      padding-top: calc(var(--global-nav-height) + 20px);
+      box-sizing: border-box;
     }
 
     #gameButton {
@@ -40,10 +44,9 @@
       color: white;
       border-radius: 4px;
       transition: background-color 0.3s;
-      top: 50%;
-      width: 300px;
-      height: 120px;
-      margin: 20% 0% 20% 0;
+      width: min(100%, 320px);
+      min-height: 96px;
+      margin: 0 auto;
     }
 
     #gameButton:hover {
@@ -94,14 +97,16 @@
     }
 
     div[id$="Modal"]>div {
-      margin: 100px auto;
+      margin: 10vh auto;
       padding: 20px;
       background-color: white;
-      width: 50%;
-      min-width: 350px;
+      width: min(92vw, 520px);
+      max-height: 80vh;
+      overflow-y: auto;
       text-align: left;
       border-radius: 10px;
       box-shadow: 0px 5px 15px rgba(0, 0, 0, 0.2);
+      box-sizing: border-box;
     }
 
     div[id$="Modal"] button {
@@ -134,17 +139,19 @@
       height: 200px;
       border: 1px solid #ddd;
       padding: 10px;
+      overflow-x: auto;
+      gap: 5px;
+      box-sizing: border-box;
     }
 
     .bar {
       width: 20px;
       height: 100%;
-      margin-right: 5px;
+      flex: 0 0 20px;
       background-color: #4caf50;
     }
 
     #iconTray {
-      top: 100px;
       width: 100%;
       padding: 10px;
       display: flex;
@@ -154,16 +161,30 @@
 
     #feedback {
       width: 100%;
-      height: 30px;
-      bottom: 150px;
+      min-height: 30px;
       text-align: center;
-      margin: 20% 0 20% 0;
+      margin: 6vh 0;
     }
 
     content {
-      width: 400px;
-      margin: auto;
+      width: min(92vw, 420px);
+      margin: 0 auto;
       display: block;
+      box-sizing: border-box;
+    }
+
+    @media (max-width: 480px) {
+      body {
+        padding-top: calc(var(--global-nav-height) + 12px);
+      }
+
+      #gameButton {
+        font-size: 18px;
+      }
+
+      #feedback {
+        margin: 4vh 0;
+      }
     }
   </style>
   <script type="text/javascript" src="/mixpanel.js"></script>


### PR DESCRIPTION
### Motivation
- The reaction game used fixed heights and large top margins which made the primary button and modals unreachable on small viewports, so the page needs to be playable on mobile. 
- Modals and the reaction-graph could overflow or be clipped on narrow screens, reducing usability on phones.

### Description
- Reworked page layout to use viewport-safe sizing and flex layout by replacing fixed top padding/height with `min-height: 100svh`, `display: flex`, and centered content alignment in `body` and added `box-sizing: border-box`.
- Made the primary button responsive by changing `#gameButton` to `width: min(100%, 320px)`, `min-height: 96px`, and centered margins so it fits narrow screens without overflow.
- Made modals responsive by replacing rigid `width`/`min-width` with `width: min(92vw, 520px)`, adding `max-height: 80vh` and `overflow-y: auto`, and reducing top margin to `10vh` so dialogs fit and scroll on mobile.
- Improved graph container by enabling horizontal scroll with `overflow-x: auto`, switching bars to fixed flex-basis (`flex: 0 0 20px`) to avoid clipping, and added a small-screen media query (`@media (max-width: 480px)`) to tune spacing and font-size.

### Testing
- No automated tests were run because this is a static UI change and the repository contains no automated test harness for this page.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e51bff1a3c8331a925b84ed2d23749)