### PR TITLE
Improve Guess Hue intro screen

### DIFF
--- a/guesshue/index.html
+++ b/guesshue/index.html
@@ -18,9 +18,148 @@
   <meta name="author" content="Stuart Pecksen">
   <style>
     body {
-      background-color: #f4f4f4;
+      background:
+        radial-gradient(circle at top left, rgba(255, 112, 186, 0.22), transparent 28rem),
+        radial-gradient(circle at top right, rgba(85, 214, 255, 0.22), transparent 26rem),
+        #f4f4f4;
       font-family: "Roboto", sans-serif;
       text-align: center;
+      margin: 0;
+      min-height: 100vh;
+    }
+
+    .intro-screen {
+      box-sizing: border-box;
+      display: flex;
+      justify-content: center;
+      padding: 76px 18px 28px;
+      width: 100%;
+    }
+
+    .intro-card {
+      background: rgba(255, 255, 255, 0.92);
+      border: 1px solid rgba(17, 17, 17, 0.08);
+      border-radius: 28px;
+      box-shadow: 0 24px 70px rgba(0, 0, 0, 0.14);
+      box-sizing: border-box;
+      max-width: 680px;
+      overflow: hidden;
+      padding: 28px;
+      position: relative;
+      width: 100%;
+    }
+
+    .intro-card::before {
+      background: linear-gradient(90deg, #ff5f7e, #ffb84d, #4ddc84, #4dc7ff, #a56bff);
+      content: "";
+      height: 8px;
+      left: 0;
+      position: absolute;
+      right: 0;
+      top: 0;
+    }
+
+    .intro-kicker {
+      color: #666;
+      font-size: 0.78rem;
+      font-weight: 800;
+      letter-spacing: 0.14em;
+      margin: 8px 0 10px;
+      text-transform: uppercase;
+    }
+
+    .intro-card h1 {
+      color: #111;
+      font-size: clamp(2.4rem, 9vw, 4.6rem);
+      line-height: 0.95;
+      margin: 0;
+    }
+
+    .intro-lede {
+      color: #333;
+      font-size: clamp(1.05rem, 3vw, 1.3rem);
+      line-height: 1.5;
+      margin: 18px auto 0;
+      max-width: 520px;
+    }
+
+    .intro-preview {
+      display: grid;
+      gap: 8px;
+      grid-template-columns: repeat(3, 1fr);
+      margin: 26px auto;
+      max-width: 228px;
+    }
+
+    .intro-swatch {
+      aspect-ratio: 1;
+      background: #6cc8ff;
+      border-radius: 16px;
+      box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.38);
+    }
+
+    .intro-swatch--odd {
+      background: #80d4ff;
+      position: relative;
+    }
+
+    .intro-swatch--odd::after {
+      background: #111;
+      border-radius: 999px;
+      color: #fff;
+      content: "Tap";
+      font-size: 0.75rem;
+      font-weight: 800;
+      left: 50%;
+      padding: 4px 8px;
+      position: absolute;
+      top: 50%;
+      transform: translate(-50%, -50%) rotate(-8deg);
+    }
+
+    .intro-rules {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(3, 1fr);
+      margin: 0 auto 26px;
+      max-width: 620px;
+    }
+
+    .intro-rule {
+      background: #f7f7f7;
+      border-radius: 16px;
+      color: #222;
+      font-size: 0.95rem;
+      line-height: 1.35;
+      padding: 14px;
+    }
+
+    .intro-rule strong {
+      display: block;
+      font-size: 1.45rem;
+      margin-bottom: 4px;
+    }
+
+    .intro-actions {
+      align-items: center;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .intro-high-score {
+      color: #555;
+      font-size: 0.95rem;
+      margin: 0;
+    }
+
+    .game-shell {
+      display: none;
+      padding-top: 1px;
+    }
+
+    .game-shell.is-active {
+      display: block;
     }
 
     .container {
@@ -229,6 +368,19 @@
       p {
         font-size: 1.2rem;
       }
+
+      .intro-screen {
+        padding-top: 68px;
+      }
+
+      .intro-card {
+        border-radius: 22px;
+        padding: 24px 18px;
+      }
+
+      .intro-rules {
+        grid-template-columns: 1fr;
+      }
     }
 
     #welcome {
@@ -269,9 +421,38 @@
 
 <body>
   <div id="navbar-container"></div>
-  <div id="streakCounter">Streak: <span id="streak">0</span></div>
-  <div id="timer"></div>
-  <div class="container"></div>
+  <section id="introScreen" class="intro-screen" aria-labelledby="introTitle">
+    <div class="intro-card">
+      <p class="intro-kicker">Colour perception sprint</p>
+      <h1 id="introTitle">Guess Hue</h1>
+      <p class="intro-lede">Find the one square that is just a little different. The clock starts when you press play, so take a breath and get your eyes ready.</p>
+      <div class="intro-preview" aria-hidden="true">
+        <span class="intro-swatch"></span>
+        <span class="intro-swatch"></span>
+        <span class="intro-swatch intro-swatch--odd"></span>
+        <span class="intro-swatch"></span>
+        <span class="intro-swatch"></span>
+        <span class="intro-swatch"></span>
+        <span class="intro-swatch"></span>
+        <span class="intro-swatch"></span>
+        <span class="intro-swatch"></span>
+      </div>
+      <div class="intro-rules" aria-label="How to play">
+        <div class="intro-rule"><strong>1</strong>Spot the odd shade in the 3 by 3 grid.</div>
+        <div class="intro-rule"><strong>2</strong>You get 4 seconds for each round.</div>
+        <div class="intro-rule"><strong>3</strong>Keep choosing correctly to build your streak.</div>
+      </div>
+      <div class="intro-actions">
+        <button id="startButton" class="button-85">Start playing</button>
+        <p class="intro-high-score">Best streak: <span id="introHighScore">0</span></p>
+      </div>
+    </div>
+  </section>
+  <main id="gameShell" class="game-shell" aria-live="polite">
+    <div id="streakCounter">Streak: <span id="streak">0</span></div>
+    <div id="timer"></div>
+    <div class="container"></div>
+  </main>
   <div id="gameOverScreen">
     Game Over!<br />
     <div class="statContainer">
@@ -321,6 +502,7 @@
     };
 
     let highScore = loadHighScore();
+    document.getElementById('introHighScore').textContent = highScore;
 
     const updateStreakDisplay = () => {
       document.getElementById("streak").textContent = streak;
@@ -392,8 +574,15 @@
         highScore = streak;
         localStorage.setItem('highScore', highScore);
         document.getElementById('highScore').textContent = highScore;
+        document.getElementById('introHighScore').textContent = highScore;
         document.getElementById('newRecord').style.display = 'block';
       }
+    };
+
+    const startGame = () => {
+      document.getElementById("introScreen").style.display = "none";
+      document.getElementById("gameShell").classList.add("is-active");
+      restartGame();
     };
 
     const restartGame = () => {
@@ -409,6 +598,7 @@
       document.getElementById('newRecord').style.display = 'none';
     };
 
+    document.getElementById("startButton").addEventListener("click", startGame);
     document.getElementById("restartButton").addEventListener("click", restartGame);
 
 
@@ -452,48 +642,24 @@
       }
     };
 
-    initGameBoard();
   </script>
 
-<script data-explainer-injected="v1">
+<script data-explainer-injected="v2">
 (function () {
-  const storageKey = "explainerSeen_guesshue_v1";
-  const modal = document.createElement("div");
-  modal.style.cssText = "position:fixed;inset:0;background:rgba(0,0,0,.65);display:none;align-items:center;justify-content:center;z-index:9999;padding:16px;";
-  modal.innerHTML = `<div style="max-width:520px;width:100%;background:#fff;color:#111;padding:20px;border-radius:12px;font-family:Arial,sans-serif;box-shadow:0 16px 40px rgba(0,0,0,.35);">
-      <h2 style="margin:0 0 8px 0;font-size:1.3rem;">How to play Guess Hue</h2>
-      <p style="line-height:1.45;margin:0 0 16px 0;">Tap the one square with a slightly different color. Correct picks level you up; mistakes cost lives.</p>
-      <button id="explainerCloseBtn" style="padding:10px 14px;border:0;border-radius:8px;background:#111;color:#fff;cursor:pointer;">Got it</button>
-    </div>`;
-
   const helpBtn = document.createElement("button");
   helpBtn.type = "button";
-  helpBtn.setAttribute("aria-label", "Open game explainer");
+  helpBtn.setAttribute("aria-label", "Show Guess Hue instructions");
   helpBtn.textContent = "?";
   helpBtn.style.cssText = "position:fixed;top:12px;right:12px;width:36px;height:36px;border-radius:999px;border:none;background:#111;color:#fff;font-weight:700;cursor:pointer;z-index:9998;";
 
-  function openExplainer() {
-    modal.style.display = "flex";
-  }
-
-  function closeExplainer(markSeen) {
-    modal.style.display = "none";
-    if (markSeen) localStorage.setItem(storageKey, "true");
-  }
+  helpBtn.addEventListener("click", function () {
+    clearInterval(timer);
+    document.getElementById("gameShell").classList.remove("is-active");
+    document.getElementById("gameOverScreen").style.display = "none";
+    document.getElementById("introScreen").style.display = "flex";
+  });
 
   document.body.appendChild(helpBtn);
-  document.body.appendChild(modal);
-  helpBtn.addEventListener("click", openExplainer);
-  modal.addEventListener("click", function (event) {
-    if (event.target === modal) closeExplainer(true);
-  });
-  modal.querySelector("#explainerCloseBtn").addEventListener("click", function () {
-    closeExplainer(true);
-  });
-
-  if (localStorage.getItem(storageKey) !== "true") {
-    openExplainer();
-  }
 })();
 </script>
 


### PR DESCRIPTION
### Motivation
- Give players a clearer, more polished entry point before the game begins so the timer doesn't start immediately.
- Surface the rules, a small preview and the best-streak to reduce confusion and improve first-time UX.
- Replace the older explainer modal with a help control that returns players to the new intro screen.

### Description
- Add a styled intro card, preview swatches, rules and `Start playing` CTA to `guesshue/index.html` and introduce an `#introScreen` layout with responsive styles.
- Gate the live game behind a `#gameShell` element and add a `startGame` function so `initGameBoard()` is only called after pressing the `startButton`.
- Sync the saved high score into the intro via `introHighScore` and update it when a new record is set.
- Replace the injected modal explainer with a help button that pauses the timer and shows the intro screen instead of auto-opening a modal.

### Testing
- Ran a Python HTML parser smoke test asserting the presence of `id="introScreen"`, `id="startButton"`, `id="gameShell"`, `const startGame = () =>` and that `initGameBoard();` appears exactly once, and the test passed.
- Attempted to exercise a Playwright screenshot flow, but installing Playwright failed with an `npm` registry `403 Forbidden` in this environment so browser-driven screenshots could not be completed.
- Verified the modified file is `guesshue/index.html` and the runtime gating logic is in place via automated string checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a018bb6768c8331a86741eeea363d6f)