### PR TITLE
Improve home screen layout

### DIFF
--- a/home.css
+++ b/home.css
@@ -1,68 +1,99 @@
 :root {
-  --bg: #081126;
-  --bg-soft: #111c35;
-  --panel: rgba(13, 24, 46, 0.78);
-  --text-primary: #f5f8ff;
-  --text-secondary: #adc0e5;
-  --brand: #59c8ff;
-  --brand-strong: #7a6dff;
-  --accent: #ff5db1;
+  --bg: #050917;
+  --bg-soft: #0b1732;
+  --surface: rgba(10, 19, 42, 0.82);
+  --surface-strong: rgba(17, 29, 58, 0.92);
+  --text-primary: #f4f8ff;
+  --text-secondary: #b7c4dc;
+  --brand: #69d8ff;
+  --brand-2: #8c7dff;
+  --brand-3: #ff67ba;
   --border: rgba(135, 170, 255, 0.28);
   --radius-md: 14px;
-  --radius-lg: 22px;
-  --shadow-soft: 0 10px 24px rgba(0, 0, 0, 0.26);
-  --shadow-strong: 0 18px 42px rgba(0, 0, 0, 0.35);
+  --radius-lg: 24px;
+  --shadow-soft: 0 14px 34px rgba(0, 0, 0, 0.28);
+  --shadow-strong: 0 22px 54px rgba(0, 0, 0, 0.42);
 }
 
 * {
   box-sizing: border-box;
 }
 
+html {
+  scroll-behavior: smooth;
+}
+
 body {
   margin: 0;
-  padding: calc(var(--global-nav-height) + 1.5rem) 0 0;
+  padding: calc(var(--global-nav-height) + 1.25rem) 0 0;
+  min-height: 100vh;
   background:
-    radial-gradient(circle at 18% 10%, rgba(99, 198, 255, 0.22), transparent 34%),
-    radial-gradient(circle at 86% 0%, rgba(182, 101, 255, 0.22), transparent 28%),
-    linear-gradient(160deg, var(--bg), var(--bg-soft));
+    radial-gradient(circle at 14% 8%, rgba(105, 216, 255, 0.22), transparent 32rem),
+    radial-gradient(circle at 88% 2%, rgba(255, 103, 186, 0.2), transparent 26rem),
+    linear-gradient(160deg, var(--bg), var(--bg-soft) 58%, #090d22);
   font-family: 'Manrope', system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
   color: var(--text-primary);
   line-height: 1.45;
 }
 
+body::before {
+  content: '';
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  pointer-events: none;
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.035) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.03) 1px, transparent 1px);
+  background-size: 48px 48px;
+  mask-image: linear-gradient(to bottom, black, transparent 78%);
+}
+
+.home-hero,
+.game-discovery,
+.content,
+.seo-content {
+  width: min(100% - 2rem, 1240px);
+  margin-inline: auto;
+}
+
 .home-hero {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1.2rem 2rem 1.4rem;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(280px, 420px);
+  gap: clamp(1.25rem, 3vw, 2.25rem);
+  align-items: end;
+  padding: 1.1rem 0 1rem;
 }
 
 .hero-kicker {
   margin: 0;
   font-family: 'Space Grotesk', sans-serif;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
   font-size: 0.78rem;
   color: var(--brand);
 }
 
 .home-hero h1 {
-  margin: 0.55rem 0 0.65rem;
-  max-width: 22ch;
+  margin: 0.55rem 0 0.7rem;
+  max-width: 16ch;
   font-family: 'Space Grotesk', sans-serif;
-  font-size: clamp(1.7rem, 4.1vw, 2.8rem);
-  line-height: 1.1;
+  font-size: clamp(2.35rem, 7vw, 5rem);
+  line-height: 0.94;
+  letter-spacing: -0.06em;
 }
 
 .hero-subtitle {
   margin: 0;
-  max-width: 64ch;
+  max-width: 62ch;
   color: var(--text-secondary);
+  font-size: clamp(1rem, 1.5vw, 1.15rem);
 }
 
 .hero-chips {
   display: flex;
   gap: 0.65rem;
-  margin-top: 1rem;
+  margin-top: 1.15rem;
   flex-wrap: wrap;
 }
 
@@ -71,87 +102,217 @@ body {
   border: 1px solid rgba(89, 200, 255, 0.35);
   color: #d2ecff;
   border-radius: 999px;
-  padding: 0.32rem 0.7rem;
+  padding: 0.38rem 0.78rem;
   font-size: 0.82rem;
-  font-weight: 600;
+  font-weight: 700;
 }
 
+.hero-panel {
+  position: relative;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius-lg) + 4px);
+  padding: 1.1rem;
+  background:
+    linear-gradient(145deg, rgba(105, 216, 255, 0.12), rgba(255, 103, 186, 0.1)),
+    rgba(8, 15, 34, 0.74);
+  box-shadow: var(--shadow-soft);
+}
+
+.hero-panel::before {
+  content: '';
+  position: absolute;
+  inset: auto -20% -45% 28%;
+  height: 200px;
+  border-radius: 50%;
+  background: rgba(105, 216, 255, 0.22);
+  filter: blur(32px);
+}
+
+.hero-panel-label,
+.hero-panel-title,
+.hero-panel-copy,
+.hero-stat {
+  position: relative;
+}
+
+.hero-panel-label {
+  margin: 0 0 0.9rem;
+  color: var(--text-secondary);
+  font-size: 0.82rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.hero-panel-title {
+  margin: 0;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.45rem;
+}
+
+.hero-panel-copy {
+  margin: 0.45rem 0 1rem;
+  color: var(--text-secondary);
+}
+
+.hero-stats {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 0.65rem;
+}
+
+.hero-stat {
+  min-height: 84px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 18px;
+  padding: 0.85rem;
+  background: rgba(255, 255, 255, 0.055);
+}
+
+.hero-stat strong {
+  display: block;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.55rem;
+}
+
+.hero-stat span {
+  display: block;
+  color: var(--text-secondary);
+  font-size: 0.8rem;
+  font-weight: 700;
+}
 
 .game-discovery {
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 0.4rem 2rem 0.4rem;
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) auto;
+  gap: 1rem;
+  align-items: end;
+  margin-top: 0.7rem;
+  padding: 1rem;
+  border: 1px solid rgba(135, 170, 255, 0.2);
+  border-radius: var(--radius-lg);
+  background: rgba(8, 15, 34, 0.68);
+  box-shadow: 0 10px 28px rgba(0, 0, 0, 0.18);
+  backdrop-filter: blur(14px);
 }
 
 .search-label {
   display: block;
-  font-weight: 700;
+  font-weight: 800;
   margin-bottom: 0.45rem;
 }
 
 #gameSearch {
   width: 100%;
-  max-width: 720px;
-  border-radius: 12px;
+  border-radius: 16px;
   border: 1px solid var(--border);
-  padding: 0.72rem 0.85rem;
-  background: rgba(255, 255, 255, 0.05);
+  padding: 0.88rem 1rem;
+  background: rgba(255, 255, 255, 0.06);
   color: var(--text-primary);
+  font: inherit;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+}
+
+#gameSearch:focus {
+  border-color: rgba(105, 216, 255, 0.85);
+  background: rgba(255, 255, 255, 0.085);
+  box-shadow: 0 0 0 4px rgba(105, 216, 255, 0.14);
 }
 
 .filter-chips {
-  margin-top: 0.7rem;
   display: flex;
   flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 0.5rem;
 }
 
 .filter-chip {
   border: 1px solid var(--border);
-  background: rgba(255, 255, 255, 0.04);
+  background: rgba(255, 255, 255, 0.045);
   color: var(--text-primary);
   border-radius: 999px;
-  padding: 0.35rem 0.72rem;
+  padding: 0.62rem 0.86rem;
   cursor: pointer;
+  font-weight: 800;
+  transition: transform 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+
+.filter-chip:hover,
+.filter-chip:focus-visible {
+  transform: translateY(-1px);
+  border-color: rgba(105, 216, 255, 0.72);
 }
 
 .filter-chip.active {
-  border-color: rgba(122, 109, 255, 0.9);
-  background: rgba(122, 109, 255, 0.25);
+  border-color: rgba(122, 109, 255, 0.95);
+  background: linear-gradient(120deg, rgba(122, 109, 255, 0.36), rgba(255, 103, 186, 0.24));
 }
 
 .filter-empty {
-  max-width: 1200px;
+  width: min(100% - 2rem, 1240px);
   margin: 0 auto;
-  padding: 0 2rem 1rem;
+  padding: 0 0 1rem;
   color: var(--text-secondary);
 }
 
 .content {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-  gap: 1.35rem;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 1rem 2rem 2.2rem;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  grid-auto-flow: dense;
+  gap: clamp(0.9rem, 1.6vw, 1.35rem);
+  padding: 1.2rem 0 2.35rem;
+}
+
+.grid-heading {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: end;
+  margin-top: 0.35rem;
+}
+
+.grid-heading h2 {
+  margin: 0;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: clamp(1.45rem, 2.4vw, 2rem);
+}
+
+.grid-heading p {
+  margin: 0;
+  max-width: 48ch;
+  color: var(--text-secondary);
+  text-align: right;
 }
 
 .tile {
   display: flex;
   min-width: 0;
+  grid-column: span 3;
+}
+
+.tile.featured {
+  grid-column: span 6;
+}
+
+.tile.wide {
+  grid-column: span 4;
 }
 
 .ad-tile {
   align-items: stretch;
-}
-
-.ad-tile {
-  align-items: stretch;
+  grid-column: span 6;
 }
 
 .game {
+  --accent-a: rgba(122, 109, 255, 0.95);
+  --accent-b: rgba(255, 93, 177, 0.95);
   cursor: pointer;
-  min-height: 248px;
+  aspect-ratio: 16 / 12;
+  min-height: 234px;
   width: 100%;
   border-radius: var(--radius-lg);
   overflow: hidden;
@@ -162,23 +323,39 @@ body {
   justify-content: flex-end;
   text-decoration: none;
   color: inherit;
-
   border: 1px solid var(--border);
-
-
   box-shadow: var(--shadow-soft);
   position: relative;
   isolation: isolate;
+  transform: translateZ(0);
   transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
-  max-width: 100%;
+}
+
+.featured .game {
+  aspect-ratio: 16 / 9;
+  min-height: 310px;
+}
+
+.wide .game {
+  aspect-ratio: 16 / 10;
 }
 
 .game::before {
   content: '';
   position: absolute;
   inset: 0;
+  z-index: -2;
+  background: linear-gradient(to top, rgba(2, 8, 24, 0.96), rgba(5, 12, 32, 0.42) 52%, rgba(5, 12, 32, 0.08) 100%);
+}
+
+.game::after {
+  content: '';
+  position: absolute;
+  inset: auto 0 0;
   z-index: -1;
-  background: linear-gradient(to top, rgba(2, 8, 24, 0.95), rgba(5, 12, 32, 0.32) 50%, transparent 85%);
+  height: 42%;
+  background: linear-gradient(95deg, var(--accent-a), var(--accent-b));
+  opacity: 0.92;
 }
 
 .game:focus-visible {
@@ -187,44 +364,76 @@ body {
 }
 
 .game:hover {
-  transform: translateY(-6px);
+  transform: translateY(-7px) scale(1.01);
   box-shadow: var(--shadow-strong);
-  border-color: rgba(154, 202, 255, 0.65);
+  border-color: rgba(154, 202, 255, 0.68);
 }
 
 .gameTitle {
-  background: transparent;
   color: #fff;
   padding: 0 1rem 0.35rem;
   font-family: 'Space Grotesk', sans-serif;
-  font-size: 1.25rem;
+  font-size: clamp(1.18rem, 1.7vw, 1.55rem);
   font-weight: 700;
-  text-shadow: 0 3px 12px rgba(0, 0, 0, 0.55);
+  text-shadow: 0 3px 14px rgba(0, 0, 0, 0.62);
+}
+
+.featured .gameTitle {
+  padding-inline: 1.2rem;
+  font-size: clamp(1.6rem, 2.8vw, 2.25rem);
 }
 
 .gameInfo {
-  background: linear-gradient(95deg, rgba(122, 109, 255, 0.95), rgba(255, 93, 177, 0.95));
   color: white;
-  min-height: 56px;
-  padding: 0.55rem 0.9rem 0.65rem;
+  min-height: 70px;
+  padding: 0 1rem 0.9rem;
   display: flex;
-  align-items: center;
-  font-size: 0.9rem;
-  font-weight: 600;
+  align-items: flex-start;
+  font-size: 0.92rem;
+  font-weight: 700;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
 }
 
+.featured .gameInfo {
+  min-height: 82px;
+  padding-inline: 1.2rem;
+  font-size: 1.02rem;
+}
+
+#bludle .game { --accent-a: rgba(19, 137, 255, 0.94); --accent-b: rgba(67, 213, 255, 0.94); }
+#werdle .game { --accent-a: rgba(72, 190, 125, 0.94); --accent-b: rgba(84, 126, 255, 0.94); }
+#reaction .game,
+#alternate .game,
+#trak .game { --accent-a: rgba(255, 139, 75, 0.95); --accent-b: rgba(255, 74, 128, 0.95); }
+#shiftyFades .game,
+#colourMatch .game,
+#tintuition .game,
+#guesshue .game,
+#seequence .game,
+#chromaLock .game { --accent-a: rgba(20, 184, 166, 0.95); --accent-b: rgba(144, 97, 255, 0.95); }
+#codle .game,
+#hunt .game,
+#connex .game,
+#wordmash .game,
+#snoules .game,
+#heardle .game { --accent-a: rgba(126, 87, 255, 0.95); --accent-b: rgba(68, 170, 255, 0.95); }
+
 .coffee-button {
-  height: 56px;
-  width: 200px;
-  margin: 0 auto 0.55rem;
+  height: 52px;
+  width: min(200px, calc(100% - 2rem));
+  object-fit: contain;
+  margin: 0 auto 0.8rem;
+  filter: drop-shadow(0 8px 18px rgba(0, 0, 0, 0.45));
 }
 
 .ad-card {
   width: 100%;
-  min-height: 248px;
+  min-height: 234px;
   border-radius: var(--radius-lg);
-  border: 1px solid var(--border);
-  background: rgba(6, 13, 28, 0.82);
+  border: 1px dashed rgba(135, 170, 255, 0.36);
+  background:
+    linear-gradient(135deg, rgba(105, 216, 255, 0.08), rgba(255, 103, 186, 0.08)),
+    rgba(6, 13, 28, 0.78);
   box-shadow: var(--shadow-soft);
   padding: 1rem;
 }
@@ -250,9 +459,11 @@ body {
 }
 
 .seo-content {
-  max-width: 1200px;
-  margin: 0 auto 2rem;
-  padding: 1.25rem 2rem 0;
+  margin-bottom: 2rem;
+  padding: 1.4rem;
+  border: 1px solid rgba(135, 170, 255, 0.18);
+  border-radius: var(--radius-lg);
+  background: rgba(7, 14, 32, 0.52);
   color: var(--text-secondary);
 }
 
@@ -277,7 +488,7 @@ body {
   background: linear-gradient(180deg, rgba(10, 18, 37, 0.88), rgba(10, 18, 37, 1));
   border-top: 1px solid var(--border);
   color: var(--text-secondary);
-  padding: 2rem;
+  padding: 2rem max(1rem, calc((100vw - 1240px) / 2));
 }
 
 .footer-section h4 {
@@ -304,35 +515,113 @@ body {
   color: #cdefff;
 }
 
-@media (max-width: 700px) {
+@media (max-width: 1050px) {
+  .home-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .home-hero h1 {
+    max-width: 18ch;
+  }
+
+  .game-discovery {
+    grid-template-columns: 1fr;
+  }
+
+  .filter-chips {
+    justify-content: flex-start;
+  }
+
+  .tile,
+  .tile.wide {
+    grid-column: span 4;
+  }
+
+  .tile.featured,
+  .ad-tile {
+    grid-column: span 6;
+  }
+}
+
+@media (max-width: 760px) {
   html,
   body {
     overflow-x: clip;
   }
 
   body {
-    padding-top: calc(var(--global-nav-height) + 1rem);
+    padding-top: calc(var(--global-nav-height) + 0.85rem);
   }
 
   .home-hero,
   .game-discovery,
   .content,
   .seo-content,
-  .footer {
-    padding-left: 1rem;
-    padding-right: 1rem;
+  .filter-empty {
+    width: min(100% - 1.25rem, 1240px);
+  }
+
+  .home-hero {
+    padding-top: 0.4rem;
+  }
+
+  .home-hero h1 {
+    max-width: 12ch;
+  }
+
+  .hero-stats {
+    grid-template-columns: 1fr;
+  }
+
+  .game-discovery {
+    padding: 0.8rem;
+  }
+
+  #gameSearch {
+    padding: 0.8rem 0.9rem;
+  }
+
+  .filter-chip {
+    flex: 1 1 auto;
+    padding-inline: 0.72rem;
+  }
+
+  .grid-heading {
+    display: block;
+  }
+
+  .grid-heading p {
+    margin-top: 0.35rem;
+    text-align: left;
   }
 
   .content {
     grid-template-columns: 1fr;
     gap: 1rem;
+    padding-top: 1rem;
   }
 
-  .game {
-    min-height: 220px;
+  .tile,
+  .tile.wide,
+  .tile.featured,
+  .ad-tile {
+    grid-column: 1 / -1;
   }
 
-  .gameInfo {
-    font-size: 0.85rem;
+  .game,
+  .wide .game,
+  .featured .game {
+    aspect-ratio: 16 / 11;
+    min-height: 218px;
+  }
+
+  .game::after {
+    height: 46%;
+  }
+
+  .gameInfo,
+  .featured .gameInfo {
+    min-height: 66px;
+    font-size: 0.88rem;
   }
 }

--- a/home.css
+++ b/home.css
@@ -294,6 +294,10 @@ body::before {
   grid-column: span 3;
 }
 
+.tile[hidden] {
+  display: none;
+}
+
 .tile.featured {
   grid-column: span 6;
 }
@@ -353,9 +357,9 @@ body::before {
   position: absolute;
   inset: auto 0 0;
   z-index: -1;
-  height: 42%;
-  background: linear-gradient(95deg, var(--accent-a), var(--accent-b));
-  opacity: 0.92;
+  height: 35%;
+  background: linear-gradient(to top, rgba(2, 8, 24, 0.35), transparent);
+  pointer-events: none;
 }
 
 .game:focus-visible {
@@ -371,32 +375,36 @@ body::before {
 
 .gameTitle {
   color: #fff;
-  padding: 0 1rem 0.35rem;
+  padding: 0.82rem 1rem 0.14rem;
+  background: linear-gradient(95deg, var(--accent-a), var(--accent-b));
   font-family: 'Space Grotesk', sans-serif;
   font-size: clamp(1.18rem, 1.7vw, 1.55rem);
   font-weight: 700;
-  text-shadow: 0 3px 14px rgba(0, 0, 0, 0.62);
+  line-height: 1.05;
+  text-shadow: 0 3px 14px rgba(0, 0, 0, 0.42);
 }
 
 .featured .gameTitle {
-  padding-inline: 1.2rem;
+  padding: 1rem 1.2rem 0.18rem;
   font-size: clamp(1.6rem, 2.8vw, 2.25rem);
 }
 
 .gameInfo {
   color: white;
-  min-height: 70px;
-  padding: 0 1rem 0.9rem;
+  min-height: 58px;
+  padding: 0.16rem 1rem 0.82rem;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
+  background: linear-gradient(95deg, var(--accent-a), var(--accent-b));
   font-size: 0.92rem;
   font-weight: 700;
-  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+  line-height: 1.25;
+  text-shadow: 0 2px 10px rgba(0, 0, 0, 0.24);
 }
 
 .featured .gameInfo {
-  min-height: 82px;
-  padding-inline: 1.2rem;
+  min-height: 64px;
+  padding: 0.18rem 1.2rem 1rem;
   font-size: 1.02rem;
 }
 
@@ -616,12 +624,18 @@ body::before {
   }
 
   .game::after {
-    height: 46%;
+    height: 32%;
+  }
+
+  .gameTitle,
+  .featured .gameTitle {
+    padding: 0.78rem 0.95rem 0.12rem;
   }
 
   .gameInfo,
   .featured .gameInfo {
-    min-height: 66px;
+    min-height: 56px;
+    padding: 0.14rem 0.95rem 0.78rem;
     font-size: 0.88rem;
   }
 }

--- a/index.html
+++ b/index.html
@@ -196,20 +196,34 @@
   <div id="navbar-container"></div>
 
   <header class="home-hero" aria-labelledby="home-title">
-    <p class="hero-kicker">Playful puzzles. Premium feel.</p>
-    <h1 id="home-title">A modern arcade for word, colour and logic games.</h1>
-    <p class="hero-subtitle">Discover daily challenges, unlimited practice modes, and fast games designed to be fun in under 5 minutes.</p>
-    <div class="hero-chips" aria-label="Game categories">
-      <span>Daily Word</span>
-      <span>Colour + Vision</span>
-      <span>Logic + Memory</span>
-      <span>Speed + Reaction</span>
+    <div class="hero-copy">
+      <p class="hero-kicker">Playful puzzles. Premium feel.</p>
+      <h1 id="home-title">A cleaner arcade for quick brain games.</h1>
+      <p class="hero-subtitle">Discover daily challenges, unlimited practice modes, and fast games designed to feel good on mobile, tablet, and desktop.</p>
+      <div class="hero-chips" aria-label="Game categories">
+        <span>Daily Word</span>
+        <span>Colour + Vision</span>
+        <span>Logic + Memory</span>
+        <span>Speed + Reaction</span>
+      </div>
     </div>
+    <aside class="hero-panel" aria-label="Bludle highlights">
+      <p class="hero-panel-label">What to play today</p>
+      <h2 class="hero-panel-title">Start with a featured puzzle, then jump into shorter rounds.</h2>
+      <p class="hero-panel-copy">The home screen now gives favourites more room while keeping every game card aligned and easy to scan.</p>
+      <div class="hero-stats" aria-label="Game library stats">
+        <div class="hero-stat"><strong>17</strong><span>games</span></div>
+        <div class="hero-stat"><strong>4</strong><span>categories</span></div>
+        <div class="hero-stat"><strong>5m</strong><span>quick plays</span></div>
+      </div>
+    </aside>
   </header>
 
   <section class="game-discovery" aria-label="Find a game">
-    <label for="gameSearch" class="search-label">Find your next game</label>
-    <input id="gameSearch" type="search" placeholder="Search by game name or type (word, colour, reaction, logic)" autocomplete="off">
+    <div class="search-field">
+      <label for="gameSearch" class="search-label">Find your next game</label>
+      <input id="gameSearch" type="search" placeholder="Search by game name or type (word, colour, reaction, logic)" autocomplete="off">
+    </div>
     <div class="filter-chips" role="group" aria-label="Filter games by category">
       <button class="filter-chip active" data-filter="all" type="button">All</button>
       <button class="filter-chip" data-filter="word" type="button">Word</button>
@@ -220,22 +234,25 @@
   </section>
 
   <main class="content" id="content">
-    <h2 class="sr-only">bludle Daily Puzzle Games</h2>
-    <div class="tile" id="bludle" data-category="word colour">
+    <div class="grid-heading">
+      <h2>Choose a game</h2>
+      <p>Featured cards span the first row; the rest settle into a consistent responsive grid.</p>
+    </div>
+    <div class="tile featured" id="bludle" data-category="word colour">
       <a class="game" href="/bludle/" aria-label="Play Bludle" style="background-image: url('./images/bludle.jpg')">
         <div class="gameTitle">Bludle</div>
         <div class="gameInfo">Decode a 5 letter word from shades of blue</div>
       </a>
     </div>
 
-    <div class="tile" id="werdle" data-category="word">
+    <div class="tile featured" id="werdle" data-category="word">
       <a class="game" href="/werdle/" aria-label="Play Werdle" style="background-image: url('./images/werdle.png')">
         <div class="gameTitle">Werdle</div>
         <div class="gameInfo">Daily word game with challenge mode</div>
       </a>
     </div>
 
-    <div class="tile" id="reaction" data-category="speed">
+    <div class="tile wide" id="reaction" data-category="speed">
       <a class="game" href="/reaction/" aria-label="Play Reaction"
         style="background-image: url('./images/reaction.jpg')">
         <div class="gameTitle">Reaction</div>
@@ -243,7 +260,7 @@
       </a>
     </div>
 
-    <div class="tile" id="shiftyFades" data-category="colour">
+    <div class="tile wide" id="shiftyFades" data-category="colour">
       <a class="game" href="/shiftyfades/" aria-label="Play Shifty Fades"
         style="background-image: url('./images/shifty.png')">
         <div class="gameTitle">Shifty Fades</div>
@@ -251,7 +268,7 @@
       </a>
     </div>
 
-    <div class="tile" id="colourMatch" data-category="colour">
+    <div class="tile wide" id="colourMatch" data-category="colour">
       <a class="game" href="/colourmatch/" aria-label="Play Colour Match"
         style="background-image: url('./images/cm.jpg')">
         <div class="gameTitle">Colo(u)r Match</div>
@@ -259,7 +276,7 @@
       </a>
     </div>
 
-    <div class="tile" id="chromaLock" data-category="colour speed">
+    <div class="tile wide" id="chromaLock" data-category="colour speed">
       <a class="game" href="/chromalock/" aria-label="Play Chroma Lock"
         style="background-image: linear-gradient(135deg, rgba(20, 184, 166, 0.88), rgba(124, 58, 237, 0.82), rgba(244, 63, 94, 0.84))">
         <div class="gameTitle">Chroma Lock</div>
@@ -267,7 +284,7 @@
       </a>
     </div>
 
-    <div class="tile" id="codle" data-category="word logic">
+    <div class="tile wide" id="codle" data-category="word logic">
       <a class="game" href="/codle/" aria-label="Play Codle" style="background-image: url('./images/codle.jpg')">
         <div class="gameTitle">Codle</div>
         <div class="gameInfo">Decode 5 letter words from a random offset</div>
@@ -282,7 +299,7 @@
       </div>
     </div>
 
-    <div class="tile" id="alternate" data-category="speed colour">
+    <div class="tile wide" id="alternate" data-category="speed colour">
       <a class="game" href="/alternate/" aria-label="Play Alternate"
         style="background-image: url('./images/alternate.jpg')">
         <div class="gameTitle">Alternate</div>
@@ -290,7 +307,7 @@
       </a>
     </div>
 
-    <div class="tile" id="tintuition" data-category="colour">
+    <div class="tile wide" id="tintuition" data-category="colour">
       <a class="game" href="/tintuition/" aria-label="Play Tintuition"
         style="background-image: url('./images/tintuition.png')">
         <div class="gameTitle">Tintuition</div>
@@ -298,7 +315,7 @@
       </a>
     </div>
 
-    <div class="tile" id="hunt" data-category="logic">
+    <div class="tile wide" id="hunt" data-category="logic">
       <a class="game" href="/hunt/" aria-label="Play XY Marks the Spot"
         style="background-image: url('./images/hunt.png')">
         <div class="gameTitle">XY Marks the Spot</div>
@@ -306,28 +323,28 @@
       </a>
     </div>
 
-    <div class="tile" id="guesshue" data-category="colour speed">
+    <div class="tile wide" id="guesshue" data-category="colour speed">
       <a class="game" href="/guesshue/" aria-label="Play Guess Hue" style="background-image: url('./images/hue.png')">
         <div class="gameTitle">Guess Hue</div>
         <div class="gameInfo">Spot the odd one out and go on a streak</div>
       </a>
     </div>
 
-    <div class="tile" id="trak" data-category="speed logic">
+    <div class="tile wide" id="trak" data-category="speed logic">
       <a class="game" href="/trak/" aria-label="Play Trak" style="background-image: url('./images/trak.png')">
         <div class="gameTitle">Trak</div>
         <div class="gameInfo">Stop the ball in the green zone. What ball?</div>
       </a>
     </div>
 
-    <div class="tile" id="connex" data-category="word logic">
+    <div class="tile wide" id="connex" data-category="word logic">
       <a class="game" href="/connex/" aria-label="Play Connex" style="background-image: url('./images/connex.png')">
         <div class="gameTitle">Connex</div>
         <div class="gameInfo">Find the 3 words from the same connection bank</div>
       </a>
     </div>
 
-    <div class="tile" id="wordmash" data-category="word logic">
+    <div class="tile wide" id="wordmash" data-category="word logic">
       <a class="game" href="/wordmash/" aria-label="Play Word Mash"
         style="background-image: url('./images/wordmash.svg')">
         <div class="gameTitle">Word Mash</div>
@@ -335,21 +352,21 @@
       </a>
     </div>
 
-    <div class="tile" id="snoules" data-category="logic speed">
+    <div class="tile wide" id="snoules" data-category="logic speed">
       <a class="game" href="/snoules/" aria-label="Play Snoules" style="background-image: url('./images/snoules.jpg')">
         <div class="gameTitle">Snoules</div>
         <div class="gameInfo">Roll the white ball. Land closest to win. Snooker meets boules.</div>
       </a>
     </div>
 
-    <div class="tile" id="heardle" data-category="logic">
+    <div class="tile wide" id="heardle" data-category="logic">
       <a class="game" href="/heardle/" aria-label="Play Heardle" style="background-image: url('./images/heardle.png')">
         <div class="gameTitle">Heardle</div>
         <div class="gameInfo">Listen carefully & play it by ear</div>
       </a>
     </div>
 
-    <div class="tile" id="seequence" data-category="colour logic">
+    <div class="tile wide" id="seequence" data-category="colour logic">
       <a class="game" href="/seequence/" aria-label="Play Seequence"
         style="background-image: url('./images/seequence.jpg')">
         <div class="gameTitle">Seequence</div>
@@ -357,7 +374,7 @@
       </a>
     </div>
 
-    <div class="tile" id="coffee" data-category="support">
+    <div class="tile wide" id="coffee" data-category="support">
       <a class="game" href="https://www.buymeacoffee.com/stuart1510K" target="_blank">
         <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee"
           class="coffee-button" />


### PR DESCRIPTION
### Motivation
- Make the home screen easier to scan and more visually consistent by reworking card sizing, row layout and hero presentation. 
- Surface featured games and highlights so favourites get more space while keeping the remainder of the library aligned in a predictable responsive grid. 
- Improve mobile and tablet readability with tuned breakpoints and clearer search/filter controls.

### Description
- Replace the single-column hero with a two-column hero that adds an informational `aside.hero-panel` and moves copy into a `div.hero-copy` for improved hierarchy in `index.html`.
- Rework the search/filter area into a compact glass panel and focusable search input, and add a `grid-heading` above the game grid for context in `index.html` and `home.css`.
- Convert the gallery into a 12-column CSS grid and introduce `tile.featured` and `tile.wide` classes so featured cards span the first row and other cards have consistent aspect ratios via CSS (`aspect-ratio`, `::before`/`::after` overlays, accent variables per game) in `home.css`.
- Polish visuals: new CSS variables, refined shadows, tuned overlays, ad/support card styling, coffee button, and updated mobile breakpoints for predictable row collapse and card sizing in `home.css`.

### Testing
- Ran `git diff --check` to validate no whitespace/merge issues and it completed without reported problems (passed). 
- Executed an HTML parser smoke test using `python3` to ensure `index.html` is parseable (passed). 
- Ran CSS smoke assertions with `python3` to verify key selectors/structure (`.content {`, `grid-template-columns: repeat(12`, `tile.featured`, `@media (max-width: 760px)`), and they were present (passed). 
- Started a local static server and validated the endpoint with `curl -I http://127.0.0.1:4173/` (responded 200 OK); attempted `npx playwright --version` to capture a browser screenshot but registry access returned `403 Forbidden`, so no browser screenshots could be taken in this environment (playwright check failed due to environment/npm access).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ae1fa62208331841f56b7da1e20cf)