### PR TITLE
Add Keyzee sponsored advert in reserved hero panel

### DIFF
--- a/home.css
+++ b/home.css
@@ -438,10 +438,10 @@ body::before {
   width: 100%;
   min-height: 234px;
   border-radius: var(--radius-lg);
-  border: 1px dashed rgba(135, 170, 255, 0.36);
+  border: 1px solid rgba(227, 175, 73, 0.55);
   background:
-    linear-gradient(135deg, rgba(105, 216, 255, 0.08), rgba(255, 103, 186, 0.08)),
-    rgba(6, 13, 28, 0.78);
+    radial-gradient(circle at 18% 12%, rgba(70, 118, 212, 0.55), transparent 48%),
+    linear-gradient(120deg, rgba(4, 14, 39, 0.96), rgba(2, 9, 26, 0.95));
   box-shadow: var(--shadow-soft);
   padding: 1rem;
 }
@@ -454,26 +454,43 @@ body::before {
   letter-spacing: 0.06em;
 }
 
+.ad-brand {
+  margin: 0 0 0.55rem;
+  color: #ffffff;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.85rem;
+  font-weight: 700;
+  letter-spacing: 0.01em;
+}
+
 .ad-title {
   margin: 0 0 0.55rem;
   font-family: 'Space Grotesk', sans-serif;
-  font-size: 1.3rem;
+  font-size: 1.42rem;
+  line-height: 1.2;
+  text-transform: uppercase;
+}
+
+.ad-title span {
+  color: #e3af49;
 }
 
 .ad-copy {
-  margin: 0 0 0.9rem;
-  color: var(--text-secondary);
+  margin: 0 0 1rem;
+  color: #c7d2e7;
+  font-size: 0.98rem;
 }
 
 .ad-link {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  width: 100%;
   padding: 0.62rem 0.95rem;
   border-radius: 12px;
-  border: 1px solid rgba(105, 216, 255, 0.42);
-  background: rgba(11, 30, 58, 0.62);
-  color: #d2ecff;
+  border: 1px solid rgba(227, 175, 73, 0.7);
+  background: #e3af49;
+  color: #041233;
   font-weight: 800;
   text-decoration: none;
   transition: background-color 0.2s ease, transform 0.2s ease;
@@ -481,7 +498,7 @@ body::before {
 
 .ad-link:hover,
 .ad-link:focus-visible {
-  background: rgba(20, 59, 104, 0.74);
+  background: #efbe60;
   transform: translateY(-1px);
 }
 

--- a/home.css
+++ b/home.css
@@ -156,27 +156,6 @@ body::before {
   color: var(--text-secondary);
 }
 
-.hero-panel-link {
-  position: relative;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.62rem 0.95rem;
-  border-radius: 12px;
-  border: 1px solid rgba(105, 216, 255, 0.42);
-  background: rgba(11, 30, 58, 0.62);
-  color: #d2ecff;
-  font-weight: 800;
-  text-decoration: none;
-  transition: background-color 0.2s ease, transform 0.2s ease;
-}
-
-.hero-panel-link:hover,
-.hero-panel-link:focus-visible {
-  background: rgba(20, 59, 104, 0.74);
-  transform: translateY(-1px);
-}
-
 .hero-stats {
   position: relative;
   display: grid;
@@ -473,6 +452,37 @@ body::before {
   font-size: 0.8rem;
   text-transform: uppercase;
   letter-spacing: 0.06em;
+}
+
+.ad-title {
+  margin: 0 0 0.55rem;
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 1.3rem;
+}
+
+.ad-copy {
+  margin: 0 0 0.9rem;
+  color: var(--text-secondary);
+}
+
+.ad-link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.62rem 0.95rem;
+  border-radius: 12px;
+  border: 1px solid rgba(105, 216, 255, 0.42);
+  background: rgba(11, 30, 58, 0.62);
+  color: #d2ecff;
+  font-weight: 800;
+  text-decoration: none;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.ad-link:hover,
+.ad-link:focus-visible {
+  background: rgba(20, 59, 104, 0.74);
+  transform: translateY(-1px);
 }
 
 .sr-only {

--- a/home.css
+++ b/home.css
@@ -156,6 +156,27 @@ body::before {
   color: var(--text-secondary);
 }
 
+.hero-panel-link {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.62rem 0.95rem;
+  border-radius: 12px;
+  border: 1px solid rgba(105, 216, 255, 0.42);
+  background: rgba(11, 30, 58, 0.62);
+  color: #d2ecff;
+  font-weight: 800;
+  text-decoration: none;
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.hero-panel-link:hover,
+.hero-panel-link:focus-visible {
+  background: rgba(20, 59, 104, 0.74);
+  transform: translateY(-1px);
+}
+
 .hero-stats {
   position: relative;
   display: grid;

--- a/index.html
+++ b/index.html
@@ -294,8 +294,9 @@
     <div class="tile ad-tile" data-category="all">
       <div class="ad-card">
         <p class="ad-label">Sponsored</p>
-        <h3 class="ad-title">Sell your home for free</h3>
-        <p class="ad-copy">List with Keyzee and skip traditional estate agent fees.</p>
+        <p class="ad-brand">keyzee</p>
+        <h3 class="ad-title">Sell for <span>free</span>. List for <span>free</span>. 0% commission.</h3>
+        <p class="ad-copy">The modern way to sell your home. Pay nothing. Keep more.</p>
         <a class="ad-link" href="https://keyzee.co.uk" target="_blank" rel="noopener noreferrer sponsored">Visit keyzee.co.uk</a>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -207,11 +207,15 @@
         <span>Speed + Reaction</span>
       </div>
     </div>
-    <aside class="hero-panel" aria-label="Sponsored advert">
-      <p class="hero-panel-label">Sponsored advert</p>
-      <h2 class="hero-panel-title">Sell your home for free with Keyzee.</h2>
-      <p class="hero-panel-copy">Skip traditional estate agent fees and get listed quickly with a simple online process.</p>
-      <a class="hero-panel-link" href="https://keyzee.co.uk" target="_blank" rel="noopener noreferrer sponsored">Visit keyzee.co.uk</a>
+    <aside class="hero-panel" aria-label="Bludle highlights">
+      <p class="hero-panel-label">What to play today</p>
+      <h2 class="hero-panel-title">Start with a featured puzzle, then jump into shorter rounds.</h2>
+      <p class="hero-panel-copy">The home screen now gives favourites more room while keeping every game card aligned and easy to scan.</p>
+      <div class="hero-stats" aria-label="Game library stats">
+        <div class="hero-stat"><strong>17</strong><span>games</span></div>
+        <div class="hero-stat"><strong>4</strong><span>categories</span></div>
+        <div class="hero-stat"><strong>5m</strong><span>quick plays</span></div>
+      </div>
     </aside>
   </header>
 
@@ -290,8 +294,9 @@
     <div class="tile ad-tile" data-category="all">
       <div class="ad-card">
         <p class="ad-label">Sponsored</p>
-        <ins class="adsbygoogle" style="display:block" data-ad-client="ca-pub-5140172230633441"
-          data-ad-slot="9823645170" data-ad-format="auto" data-full-width-responsive="true"></ins>
+        <h3 class="ad-title">Sell your home for free</h3>
+        <p class="ad-copy">List with Keyzee and skip traditional estate agent fees.</p>
+        <a class="ad-link" href="https://keyzee.co.uk" target="_blank" rel="noopener noreferrer sponsored">Visit keyzee.co.uk</a>
       </div>
     </div>
 

--- a/index.html
+++ b/index.html
@@ -207,15 +207,11 @@
         <span>Speed + Reaction</span>
       </div>
     </div>
-    <aside class="hero-panel" aria-label="Bludle highlights">
-      <p class="hero-panel-label">What to play today</p>
-      <h2 class="hero-panel-title">Start with a featured puzzle, then jump into shorter rounds.</h2>
-      <p class="hero-panel-copy">The home screen now gives favourites more room while keeping every game card aligned and easy to scan.</p>
-      <div class="hero-stats" aria-label="Game library stats">
-        <div class="hero-stat"><strong>17</strong><span>games</span></div>
-        <div class="hero-stat"><strong>4</strong><span>categories</span></div>
-        <div class="hero-stat"><strong>5m</strong><span>quick plays</span></div>
-      </div>
+    <aside class="hero-panel" aria-label="Sponsored advert">
+      <p class="hero-panel-label">Sponsored advert</p>
+      <h2 class="hero-panel-title">Sell your home for free with Keyzee.</h2>
+      <p class="hero-panel-copy">Skip traditional estate agent fees and get listed quickly with a simple online process.</p>
+      <a class="hero-panel-link" href="https://keyzee.co.uk" target="_blank" rel="noopener noreferrer sponsored">Visit keyzee.co.uk</a>
     </aside>
   </header>
 


### PR DESCRIPTION
### Motivation
- Populate the previously reserved but unused hero-side panel with an explicit sponsored advert to promote Keyzee and a “sell your home for free” CTA.

### Description
- Replaced the hero panel content in `index.html` with a sponsored advert block linking to `https://keyzee.co.uk` and included safe external attributes `target="_blank"` and `rel="noopener noreferrer sponsored"`.
- Added `.hero-panel-link` CSS in `home.css` with default, hover, and `focus-visible` styles so the CTA matches the hero panel design and is accessible.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c1817827c8331aac874053530a892)