### PR TITLE
Add Push and Shape Cut tiles to home screen with tracking and structured data

### DIFF
--- a/home.js
+++ b/home.js
@@ -51,6 +51,8 @@ const tileHandlers = {
   snoules: () => trackClick('snoules'),
   heardle: () => trackClick('heardle'),
   seequence: () => trackClick('seequence'),
+  push: () => trackClick('push'),
+  shapecut: () => trackClick('shapecut'),
   coffee: () => trackClick('coffee'),
 };
 

--- a/index.html
+++ b/index.html
@@ -89,7 +89,9 @@
         { "@id": "https://www.bludle.com/connex/" },
         { "@id": "https://www.bludle.com/reaction/" },
         { "@id": "https://www.bludle.com/guesshue/" },
-        { "@id": "https://www.bludle.com/chromalock/" }
+        { "@id": "https://www.bludle.com/chromalock/" },
+        { "@id": "https://www.bludle.com/push/" },
+        { "@id": "https://www.bludle.com/shapecut/" }
       ],
       "publisher": {
         "@id": "https://www.bludle.com/#organization"
@@ -140,7 +142,9 @@
         { "@type": "ListItem", "position": 14, "name": "Snoules", "url": "https://www.bludle.com/snoules/" },
         { "@type": "ListItem", "position": 15, "name": "Heardle", "url": "https://www.bludle.com/heardle/" },
         { "@type": "ListItem", "position": 16, "name": "Seequence", "url": "https://www.bludle.com/seequence/" },
-        { "@type": "ListItem", "position": 17, "name": "Chroma Lock", "url": "https://www.bludle.com/chromalock/" }
+        { "@type": "ListItem", "position": 17, "name": "Chroma Lock", "url": "https://www.bludle.com/chromalock/" },
+        { "@type": "ListItem", "position": 18, "name": "Push", "url": "https://www.bludle.com/push/" },
+        { "@type": "ListItem", "position": 19, "name": "Shape Cut", "url": "https://www.bludle.com/shapecut/" }
       ]
     }
   </script>
@@ -212,7 +216,7 @@
       <h2 class="hero-panel-title">Start with a featured puzzle, then jump into shorter rounds.</h2>
       <p class="hero-panel-copy">The home screen now gives favourites more room while keeping every game card aligned and easy to scan.</p>
       <div class="hero-stats" aria-label="Game library stats">
-        <div class="hero-stat"><strong>17</strong><span>games</span></div>
+        <div class="hero-stat"><strong>19</strong><span>games</span></div>
         <div class="hero-stat"><strong>4</strong><span>categories</span></div>
         <div class="hero-stat"><strong>5m</strong><span>quick plays</span></div>
       </div>
@@ -376,6 +380,22 @@
       </a>
     </div>
 
+    <div class="tile wide" id="push" data-category="logic speed">
+      <a class="game" href="/push/" aria-label="Play Push"
+        style="background-image: linear-gradient(135deg, rgba(59, 130, 246, 0.92), rgba(14, 116, 144, 0.9), rgba(6, 182, 212, 0.86))">
+        <div class="gameTitle">Push</div>
+        <div class="gameInfo">Plan each push carefully to clear the puzzle</div>
+      </a>
+    </div>
+
+    <div class="tile wide" id="shapecut" data-category="logic colour">
+      <a class="game" href="/shapecut/" aria-label="Play Shape Cut"
+        style="background-image: linear-gradient(135deg, rgba(236, 72, 153, 0.9), rgba(217, 70, 239, 0.88), rgba(129, 140, 248, 0.86))">
+        <div class="gameTitle">Shape Cut</div>
+        <div class="gameInfo">Slice across the board to reveal the target shape</div>
+      </a>
+    </div>
+
     <div class="tile wide" id="coffee" data-category="support">
       <a class="game" href="https://www.buymeacoffee.com/stuart1510K" target="_blank">
         <img src="https://cdn.buymeacoffee.com/buttons/v2/default-yellow.png" alt="Buy Me A Coffee"
@@ -466,6 +486,8 @@
         <li><a href="/seequence/" target="_blank">seequence</a></li>
         <li><a href="/wordmash/" target="_blank">word mash</a></li>
         <li><a href="/snoules/" target="_blank">snoules</a></li>
+        <li><a href="/push/" target="_blank">push</a></li>
+        <li><a href="/shapecut/" target="_blank">shape cut</a></li>
       </ul>
     </div>
   </footer>


### PR DESCRIPTION
### Motivation
- Ensure every game page has a corresponding card on the home screen so the app library is complete and discoverable.
- Include the new games in analytics so clicks on `push` and `shapecut` tiles are tracked like other games.
- Keep site metadata and visible counts in sync with the actual game list for SEO and user-facing accuracy.

### Description
- Added two game tiles to the home grid in `index.html` with IDs `push` and `shapecut`, including `data-category`, links, hero images/gradients and descriptive copy.
- Added click tracking handlers for `push` and `shapecut` to the `tileHandlers` map in `home.js` so `trackClick` is invoked on tile clicks.
- Updated structured data in `index.html` (`CollectionPage.hasPart` and `ItemList`) to include both games and updated the hero `games` stat from `17` to `19` and footer game links to include the new entries.

### Testing
- Ran repository searches (`rg`) to confirm the new tile IDs `push` and `shapecut` appear in `index.html` and `home.js`, and that structured data entries and footer links were updated (passed).
- Performed file inspection of `index.html` and `home.js` to verify the inserted markup and handler wiring are present and correctly formatted (passed).
- No automated unit tests exist for the home grid, so validation was limited to static verification of the updated files (informational).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c9caee6488331967499d7e21002f5)