### PR TITLE
Update homepage game count to reflect Snoules removal

### DIFF
--- a/index.html
+++ b/index.html
@@ -215,7 +215,7 @@
       <h2 class="hero-panel-title">Start with a featured puzzle, then jump into shorter rounds.</h2>
       <p class="hero-panel-copy">The home screen now gives favourites more room while keeping every game card aligned and easy to scan.</p>
       <div class="hero-stats" aria-label="Game library stats">
-        <div class="hero-stat"><strong>17</strong><span>games</span></div>
+        <div class="hero-stat"><strong>16</strong><span>games</span></div>
         <div class="hero-stat"><strong>4</strong><span>categories</span></div>
         <div class="hero-stat"><strong>5m</strong><span>quick plays</span></div>
       </div>


### PR DESCRIPTION
### Motivation
- Keep the site content accurate after Snoules was removed by updating the homepage games tally and ensuring there are no lingering references to the Snoules assets or paths.

### Description
- Changed the hero stats on `index.html` from `<strong>17</strong>` to `<strong>16</strong>` to reflect the current game library and removed the stale count.

### Testing
- Verified no remaining references with `rg -n "<strong>16</strong>|<strong>17</strong>|snoules|Snoules|snoule|Snoule|/snoules|snoules\.jpg" index.html globalNav/navLinks.js sitemap.xml llms.txt llms-full.txt README.md` which returned no active matches for Snoules and confirmed the displayed count update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35062e0de883318f7f03fc65b403cc)